### PR TITLE
Increase Credit-Control-Request support

### DIFF
--- a/ext-pgw/src/main/java/com/telenordigital/ext_pgw/OcsApplicationTest.java
+++ b/ext-pgw/src/main/java/com/telenordigital/ext_pgw/OcsApplicationTest.java
@@ -33,6 +33,7 @@ public class OcsApplicationTest {
     private static final long APPLICATION_ID = 4L;  // Diameter Credit Control Application (4)
 
     private static final String MSISDN = "4747900184";
+    private static final String IMSI = "242017100000228";
 
     private TestClient client;
 
@@ -65,6 +66,8 @@ public class OcsApplicationTest {
         AvpSet subscriptionId = ccrAvps.addGroupedAvp(Avp.SUBSCRIPTION_ID);
         subscriptionId.addAvp(Avp.SUBSCRIPTION_ID_TYPE, SubscriptionType.END_USER_E164);
         subscriptionId.addAvp(Avp.SUBSCRIPTION_ID_DATA, MSISDN, false);
+        subscriptionId.addAvp(Avp.SUBSCRIPTION_ID_TYPE, SubscriptionType.END_USER_IMSI);
+        subscriptionId.addAvp(Avp.SUBSCRIPTION_ID_DATA, IMSI, false);
 
         ccrAvps.addAvp(Avp.MULTIPLE_SERVICES_INDICATOR, 1);
 
@@ -111,6 +114,8 @@ public class OcsApplicationTest {
         AvpSet subscriptionId = ccrAvps.addGroupedAvp(Avp.SUBSCRIPTION_ID);
         subscriptionId.addAvp(Avp.SUBSCRIPTION_ID_TYPE, SubscriptionType.END_USER_E164);
         subscriptionId.addAvp(Avp.SUBSCRIPTION_ID_DATA, MSISDN, false);
+        subscriptionId.addAvp(Avp.SUBSCRIPTION_ID_TYPE, SubscriptionType.END_USER_IMSI);
+        subscriptionId.addAvp(Avp.SUBSCRIPTION_ID_DATA, IMSI, false);
 
         ccrAvps.addAvp(Avp.MULTIPLE_SERVICES_INDICATOR, 1);
 
@@ -161,6 +166,8 @@ public class OcsApplicationTest {
         AvpSet subscriptionId = ccrAvps.addGroupedAvp(Avp.SUBSCRIPTION_ID);
         subscriptionId.addAvp(Avp.SUBSCRIPTION_ID_TYPE, SubscriptionType.END_USER_E164);
         subscriptionId.addAvp(Avp.SUBSCRIPTION_ID_DATA, MSISDN, false);
+        subscriptionId.addAvp(Avp.SUBSCRIPTION_ID_TYPE, SubscriptionType.END_USER_IMSI);
+        subscriptionId.addAvp(Avp.SUBSCRIPTION_ID_DATA, IMSI, false);
 
         ccrAvps.addAvp(Avp.TERMINATION_CAUSE, 1, true, false); // 1 = DIAMETER_LOGOUT
 
@@ -213,6 +220,8 @@ public class OcsApplicationTest {
         AvpSet subscriptionId = ccrAvps.addGroupedAvp(Avp.SUBSCRIPTION_ID);
         subscriptionId.addAvp(Avp.SUBSCRIPTION_ID_TYPE, SubscriptionType.END_USER_E164);
         subscriptionId.addAvp(Avp.SUBSCRIPTION_ID_DATA, "4333333333", false);
+        subscriptionId.addAvp(Avp.SUBSCRIPTION_ID_TYPE, SubscriptionType.END_USER_IMSI);
+        subscriptionId.addAvp(Avp.SUBSCRIPTION_ID_DATA, IMSI, false);
 
         ccrAvps.addAvp(Avp.MULTIPLE_SERVICES_INDICATOR, 1);
 

--- a/ext-pgw/src/main/java/com/telenordigital/ext_pgw/OcsApplicationTest.java
+++ b/ext-pgw/src/main/java/com/telenordigital/ext_pgw/OcsApplicationTest.java
@@ -39,6 +39,7 @@ public class OcsApplicationTest {
     private static final String APN = "panacea";
     private static final String SGSN_MCC_MNC = "24201";
     private static final int CALLED_STATION_ID = 30;
+    private static final long BUCKET_SIZE = 500L;
 
     private TestClient client;
 
@@ -80,7 +81,7 @@ public class OcsApplicationTest {
         mscc.addAvp(Avp.RATING_GROUP, 10);
         mscc.addAvp(Avp.SERVICE_IDENTIFIER_CCA, 1);
         AvpSet requestedServiceUnits = mscc.addGroupedAvp(Avp.REQUESTED_SERVICE_UNIT);
-        requestedServiceUnits.addAvp(Avp.CC_TOTAL_OCTETS, 500000L);
+        requestedServiceUnits.addAvp(Avp.CC_TOTAL_OCTETS, BUCKET_SIZE);
         requestedServiceUnits.addAvp(Avp.CC_INPUT_OCTETS, 0L);
         requestedServiceUnits.addAvp(Avp.CC_OUTPUT_OCTETS, 0L);
 
@@ -103,7 +104,7 @@ public class OcsApplicationTest {
             Avp resultMSCC = resultAvps.getAvp(Avp.MULTIPLE_SERVICES_CREDIT_CONTROL);
             assertEquals(2001L, resultMSCC.getGrouped().getAvp(Avp.RESULT_CODE).getInteger32());
             Avp granted = resultMSCC.getGrouped().getAvp(Avp.GRANTED_SERVICE_UNIT);
-            assertEquals(500000L, granted.getGrouped().getAvp(Avp.CC_TOTAL_OCTETS).getUnsigned64());
+            assertEquals(BUCKET_SIZE, granted.getGrouped().getAvp(Avp.CC_TOTAL_OCTETS).getUnsigned64());
         } catch (AvpDataException e) {
             LOG.error("Failed to get Result-Code", e);
         }
@@ -134,7 +135,7 @@ public class OcsApplicationTest {
         mscc.addAvp(Avp.RATING_GROUP, 10);
         mscc.addAvp(Avp.SERVICE_IDENTIFIER_CCA, 1);
         AvpSet requestedServiceUnits = mscc.addGroupedAvp(Avp.REQUESTED_SERVICE_UNIT);
-        requestedServiceUnits.addAvp(Avp.CC_TOTAL_OCTETS, 400000L);
+        requestedServiceUnits.addAvp(Avp.CC_TOTAL_OCTETS, BUCKET_SIZE);
         requestedServiceUnits.addAvp(Avp.CC_INPUT_OCTETS, 0L);
         requestedServiceUnits.addAvp(Avp.CC_OUTPUT_OCTETS, 0L);
 
@@ -157,7 +158,7 @@ public class OcsApplicationTest {
             Avp resultMSCC = resultAvps.getAvp(Avp.MULTIPLE_SERVICES_CREDIT_CONTROL);
             assertEquals(2001L, resultMSCC.getGrouped().getAvp(Avp.RESULT_CODE).getInteger32());
             Avp granted = resultMSCC.getGrouped().getAvp(Avp.GRANTED_SERVICE_UNIT);
-            assertEquals(400000L, granted.getGrouped().getAvp(Avp.CC_TOTAL_OCTETS).getUnsigned64());
+            assertEquals(BUCKET_SIZE, granted.getGrouped().getAvp(Avp.CC_TOTAL_OCTETS).getUnsigned64());
         } catch (AvpDataException e) {
             LOG.error("Failed to get Result-Code", e);
         }
@@ -192,7 +193,7 @@ public class OcsApplicationTest {
         mscc.addAvp(Avp.RATING_GROUP, 10);
         mscc.addAvp(Avp.SERVICE_IDENTIFIER_CCA, 1);
         AvpSet usedServiceUnits = mscc.addGroupedAvp(Avp.USED_SERVICE_UNIT);
-        usedServiceUnits.addAvp(Avp.CC_TOTAL_OCTETS, 700000L);
+        usedServiceUnits.addAvp(Avp.CC_TOTAL_OCTETS, BUCKET_SIZE);
         usedServiceUnits.addAvp(Avp.CC_INPUT_OCTETS, 0L);
         usedServiceUnits.addAvp(Avp.CC_OUTPUT_OCTETS, 0L);
         usedServiceUnits.addAvp(Avp.CC_SERVICE_SPECIFIC_UNITS, 0L);
@@ -252,7 +253,7 @@ public class OcsApplicationTest {
         mscc.addAvp(Avp.RATING_GROUP, 10);
         mscc.addAvp(Avp.SERVICE_IDENTIFIER_CCA, 1);
         AvpSet requestedServiceUnits = mscc.addGroupedAvp(Avp.REQUESTED_SERVICE_UNIT);
-        requestedServiceUnits.addAvp(Avp.CC_TOTAL_OCTETS, 500000L);
+        requestedServiceUnits.addAvp(Avp.CC_TOTAL_OCTETS, BUCKET_SIZE);
         requestedServiceUnits.addAvp(Avp.CC_INPUT_OCTETS, 0L);
         requestedServiceUnits.addAvp(Avp.CC_OUTPUT_OCTETS, 0L);
 

--- a/ext-pgw/src/main/java/com/telenordigital/ext_pgw/OcsApplicationTest.java
+++ b/ext-pgw/src/main/java/com/telenordigital/ext_pgw/OcsApplicationTest.java
@@ -27,6 +27,8 @@ public class OcsApplicationTest {
 
     private static final Logger LOG = Logger.getLogger(OcsApplicationTest.class);
 
+    private final int VENDOR_ID_3GPP = 10415;
+
     private static final String DEST_REALM = "loltel";
     private static final String DEST_HOST = "ocs";
     private static final int COMMAND_CODE = 272; // Credit-Control
@@ -34,6 +36,9 @@ public class OcsApplicationTest {
 
     private static final String MSISDN = "4747900184";
     private static final String IMSI = "242017100000228";
+    private static final String APN = "panacea";
+    private static final String SGSN_MCC_MNC = "24201";
+    private static final int CALLED_STATION_ID = 30;
 
     private TestClient client;
 
@@ -73,10 +78,16 @@ public class OcsApplicationTest {
 
         AvpSet mscc = ccrAvps.addGroupedAvp(Avp.MULTIPLE_SERVICES_CREDIT_CONTROL);
         mscc.addAvp(Avp.RATING_GROUP, 10);
+        mscc.addAvp(Avp.SERVICE_IDENTIFIER_CCA, 1);
         AvpSet requestedServiceUnits = mscc.addGroupedAvp(Avp.REQUESTED_SERVICE_UNIT);
         requestedServiceUnits.addAvp(Avp.CC_TOTAL_OCTETS, 500000L);
         requestedServiceUnits.addAvp(Avp.CC_INPUT_OCTETS, 0L);
         requestedServiceUnits.addAvp(Avp.CC_OUTPUT_OCTETS, 0L);
+
+        AvpSet serviceInformation = ccrAvps.addGroupedAvp(Avp.SERVICE_INFORMATION, VENDOR_ID_3GPP, true, false);
+        AvpSet psInformation = serviceInformation.addGroupedAvp(Avp.PS_INFORMATION, VENDOR_ID_3GPP, true, false);
+        psInformation.addAvp(CALLED_STATION_ID, APN, false);
+        psInformation.addAvp(Avp.GPP_SGSN_MCC_MNC, SGSN_MCC_MNC, VENDOR_ID_3GPP, true, false, true);
 
         JCreditControlRequest ccr = new JCreditControlRequestImpl(request);
 
@@ -121,10 +132,16 @@ public class OcsApplicationTest {
 
         AvpSet mscc = ccrAvps.addGroupedAvp(Avp.MULTIPLE_SERVICES_CREDIT_CONTROL);
         mscc.addAvp(Avp.RATING_GROUP, 10);
+        mscc.addAvp(Avp.SERVICE_IDENTIFIER_CCA, 1);
         AvpSet requestedServiceUnits = mscc.addGroupedAvp(Avp.REQUESTED_SERVICE_UNIT);
         requestedServiceUnits.addAvp(Avp.CC_TOTAL_OCTETS, 400000L);
         requestedServiceUnits.addAvp(Avp.CC_INPUT_OCTETS, 0L);
         requestedServiceUnits.addAvp(Avp.CC_OUTPUT_OCTETS, 0L);
+
+        AvpSet serviceInformation = ccrAvps.addGroupedAvp(Avp.SERVICE_INFORMATION, VENDOR_ID_3GPP, true, false);
+        AvpSet psInformation = serviceInformation.addGroupedAvp(Avp.PS_INFORMATION, VENDOR_ID_3GPP, true, false);
+        psInformation.addAvp(CALLED_STATION_ID, APN, false);
+        psInformation.addAvp(Avp.GPP_SGSN_MCC_MNC, SGSN_MCC_MNC, VENDOR_ID_3GPP, true, false, true);
 
         JCreditControlRequest ccr = new JCreditControlRequestImpl(request);
 
@@ -173,12 +190,18 @@ public class OcsApplicationTest {
 
         AvpSet mscc = ccrAvps.addGroupedAvp(Avp.MULTIPLE_SERVICES_CREDIT_CONTROL);
         mscc.addAvp(Avp.RATING_GROUP, 10);
+        mscc.addAvp(Avp.SERVICE_IDENTIFIER_CCA, 1);
         AvpSet usedServiceUnits = mscc.addGroupedAvp(Avp.USED_SERVICE_UNIT);
         usedServiceUnits.addAvp(Avp.CC_TOTAL_OCTETS, 700000L);
         usedServiceUnits.addAvp(Avp.CC_INPUT_OCTETS, 0L);
         usedServiceUnits.addAvp(Avp.CC_OUTPUT_OCTETS, 0L);
         usedServiceUnits.addAvp(Avp.CC_SERVICE_SPECIFIC_UNITS, 0L);
         mscc.addAvp(Avp.REPORTING_REASON, 2, 10415, true, false); // 2 = FINAL , 10415 = 3GPP
+
+        AvpSet serviceInformation = ccrAvps.addGroupedAvp(Avp.SERVICE_INFORMATION, VENDOR_ID_3GPP, true, false);
+        AvpSet psInformation = serviceInformation.addGroupedAvp(Avp.PS_INFORMATION, VENDOR_ID_3GPP, true, false);
+        psInformation.addAvp(CALLED_STATION_ID, APN, false);
+        psInformation.addAvp(Avp.GPP_SGSN_MCC_MNC, SGSN_MCC_MNC, VENDOR_ID_3GPP, true, false, true);
 
         JCreditControlRequest ccr = new JCreditControlRequestImpl(request);
 
@@ -232,6 +255,11 @@ public class OcsApplicationTest {
         requestedServiceUnits.addAvp(Avp.CC_TOTAL_OCTETS, 500000L);
         requestedServiceUnits.addAvp(Avp.CC_INPUT_OCTETS, 0L);
         requestedServiceUnits.addAvp(Avp.CC_OUTPUT_OCTETS, 0L);
+
+        AvpSet serviceInformation = ccrAvps.addGroupedAvp(Avp.SERVICE_INFORMATION, VENDOR_ID_3GPP, true, false);
+        AvpSet psInformation = serviceInformation.addGroupedAvp(Avp.PS_INFORMATION, VENDOR_ID_3GPP, true, false);
+        psInformation.addAvp(CALLED_STATION_ID, APN, false);
+        psInformation.addAvp(Avp.GPP_SGSN_MCC_MNC, SGSN_MCC_MNC, VENDOR_ID_3GPP, true, false, true);
 
         JCreditControlRequest ccr = new JCreditControlRequestImpl(request);
 

--- a/ext-pgw/src/main/resources/client-jdiameter-config.xml
+++ b/ext-pgw/src/main/resources/client-jdiameter-config.xml
@@ -7,16 +7,23 @@
     <IPAddresses>
       <IPAddress value="172.16.238.2" />
     </IPAddresses>
-    <Realm value="loltel" />
-    <VendorID value="0" />
-    <ProductName value="jDiameter" />
-    <FirmwareRevision value="1" />
+    <Realm value="loltel"/>
+    <VendorID value="8164"/>
+    <ProductName value="jDiameter"/>
+    <FirmwareRevision value="1"/>
+    <Applications>
+      <ApplicationID>
+        <VendorId value="10415"/>
+        <AuthApplId value="4"/>
+        <AcctApplId value="0"/>
+      </ApplicationID>
+    </Applications>
     <OverloadMonitor>
       <Entry index="1" lowThreshold="0.5" highThreshold="0.6">
         <ApplicationID>
-          <VendorId value="0" />
-          <AuthApplId value="4" />
-          <AcctApplId value="0" />
+          <VendorId value="10415"/>
+          <AuthApplId value="4"/>
+          <AcctApplId value="10415"/>
         </ApplicationID>
       </Entry>
     </OverloadMonitor>

--- a/ocs-api/README.md
+++ b/ocs-api/README.md
@@ -1,21 +1,20 @@
 # OCS API
 
-* Fetch Data bucket
+**From P-GW to OCS**
+
+This is a translation from the DIAMETER Credit-Control-Request [RFC 4006](https://tools.ietf.org/html/rfc4006#page-9) to gRPC. Not all elements in the Credit-Control-Request is translated. Only the one we are currently using.
+
+* CreditControlRequest
+
+    CreditControlRequestInfo ( CreditControlRequestType, String requestId, String msisdn, String imsi, MultipleServiceCreditControl[], ServiceInfo serviceInformation) 
+                                
+                                => 
+                                
+                                CreditControlAnswerInfo ( String requestId, String msisdn, MultipleServiceCreditControl[] mscc)
 
 
-    fetchDataBucket (String msisdn, long bytes, int ocsgwRequestId) => (String msisdn, long bytes, int ocsgwRequestId)
 
-From PGW to OCS
-
-
-
-* Return Unused Data
-
-
-    returnUnusedData (String msisdn, int bytes) => (String msisdn)
-
-From PGW to OCS
-
+**From OCS to P-GW**
 
 
 * Activate
@@ -23,4 +22,3 @@ From PGW to OCS
 
     activate (String msisdn)
 
-From OCS to PGW

--- a/ocs-api/src/main/proto/ocs.proto
+++ b/ocs-api/src/main/proto/ocs.proto
@@ -7,25 +7,116 @@ option java_package = "com.telenordigital.prime.ocs";
 
 // OCS Service
 service OcsService {
-  rpc FetchDataBucket (stream FetchDataBucketInfo) returns (stream FetchDataBucketInfo) {}
-  rpc ReturnUnusedData (stream ReturnUnusedDataRequest) returns (stream ReturnUnusedDataResponse) {}
+  rpc CreditControlRequest (stream CreditControlRequestInfo) returns (stream CreditControlAnswerInfo) {}
   rpc Activate (ActivateRequest) returns (stream ActivateResponse) {}
 }
 
-message FetchDataBucketInfo {
-  string msisdn = 1;
-  uint64 bytes = 2;
-  string requestId = 3;
+message UserEquipmentInfo {
+  string imeisv = 1;
 }
 
-message ReturnUnusedDataRequest {
-  string msisdn = 1;
-  uint64 bytes = 2;
+message ReguestedServiceUnit {
+  uint64 totalOctets = 1;
+  uint64 inputOctets = 2;
+  uint64 outputOctetes = 3;
 }
 
-message ReturnUnusedDataResponse {
-  string msisdn = 1;
+message UsedServiceUnit {
+  uint64 totalOctets = 1;
+  uint64 inputOctets = 2;
+  uint64 outputOctetes = 3;
 }
+
+message GrantedServiceUnit {
+  uint64 totalOctets = 1;
+  uint64 inputOctets = 2;
+  uint64 outputOctetes = 3;
+}
+
+enum FinalUnitAction {
+  TERMINATE = 0;
+  REDIRECT = 1;
+  RESTRICT_ACCESS = 2;
+}
+
+enum Action {
+  PERMIT = 0;
+  DENY = 1;
+}
+
+enum Dir {
+  IN = 0;
+  OUT = 1;
+}
+
+message IPFilererRule {
+  Action action = 1;
+  Dir dir = 2;
+  string proto = 3;
+  string host = 4;
+}
+
+enum RedirectAddressType {
+  IPV4_ADDRESS = 0;
+  IPV6_ADDRESS = 1;
+  URL = 2;
+  SIP_URL = 3;
+}
+
+enum CreditControlRequestType {
+  NONE = 0;
+  INITIAL_REQUEST = 1;
+  UPDATE_REQUEST = 2;
+  TERMINATION_REQUEST = 3;
+  EVENT_REQUEST = 4;
+}
+
+message RedirectServer {
+  RedirectAddressType redirectAddressType = 1;
+  string redirectServerAddress = 2;
+}
+
+message FinalUnitIndication {
+  FinalUnitAction finalUnitAction = 1;
+  repeated IPFilererRule restrictionFilterRule = 2;
+  repeated string filterId = 3;
+  RedirectServer redirectServer = 4;
+}
+
+message MultipleServiceCreditControl {
+    uint32 serviceIdentifier = 1;
+    uint32 ratingGroup = 2;
+    ReguestedServiceUnit requested = 3;
+    UsedServiceUnit used = 4;
+    GrantedServiceUnit granted = 5;
+    FinalUnitIndication finalUnitIndication = 6;
+    uint32 validityTime = 7;
+}
+
+message PsInformation {
+  string calledStationId = 1;
+  string sgsnMccMnc = 2;
+}
+
+message ServiceInfo {
+  PsInformation psInformation = 1;
+}
+
+message CreditControlRequestInfo {
+  CreditControlRequestType type = 1;
+  string requestId = 2;
+  string msisdn = 3;
+  string imsi = 4;
+  repeated MultipleServiceCreditControl mscc = 5;
+  ServiceInfo serviceInformation = 6;
+}
+
+message CreditControlAnswerInfo {
+  string requestId = 1;
+  string msisdn = 2;
+  repeated MultipleServiceCreditControl mscc = 3;
+}
+
 
 message ActivateRequest {
 }

--- a/ocsgw/build.gradle
+++ b/ocsgw/build.gradle
@@ -34,6 +34,12 @@ dependencies {
     testRuntime 'org.junit.vintage:junit-vintage-engine:4.12.3'
 }
 
+test {
+    testLogging {
+        exceptionFormat = 'full'
+    }
+}
+
 shadowJar {
     mainClassName = 'com.telenordigital.ocsgw.OcsApplication'
     mergeServiceFiles()

--- a/ocsgw/build.gradle
+++ b/ocsgw/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 test {
     testLogging {
         exceptionFormat = 'full'
+        events "PASSED", "FAILED", "SKIPPED"
     }
 }
 

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/data/grpc/GrpcDataSource.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/data/grpc/GrpcDataSource.java
@@ -10,7 +10,6 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import org.jdiameter.api.cca.ServerCCASession;
-import org.jdiameter.api.cca.events.JCreditControlRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/data/grpc/GrpcDataSource.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/data/grpc/GrpcDataSource.java
@@ -159,7 +159,6 @@ public class GrpcDataSource implements DataSource {
 
     private CreditControlAnswer createCreditControlAnswer(CreditControlContext context, CreditControlAnswerInfo response) {
 
-        CreditControlRequest request = context.getCreditControlRequest();
         CreditControlAnswer answer = new CreditControlAnswer();
 
         if (response == null) {

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/data/grpc/GrpcDataSource.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/data/grpc/GrpcDataSource.java
@@ -74,7 +74,7 @@ public class GrpcDataSource implements DataSource {
                             if (ccrContext != null) {
                                 final ServerCCASession session = ccrContext.getSession();
                                 if (session != null) {
-                                    CreditControlAnswer cca = createCreditControlAnswer(ccrContext, answer);
+                                    CreditControlAnswer cca = createCreditControlAnswer(answer);
                                     ccrContext.sendCreditControlAnswer(cca);
                                 } else {
                                     LOG.warn("No stored CCR or Session for " + answer.getRequestId());
@@ -156,7 +156,7 @@ public class GrpcDataSource implements DataSource {
         return type;
     }
 
-    private CreditControlAnswer createCreditControlAnswer(CreditControlContext context, CreditControlAnswerInfo response) {
+    private CreditControlAnswer createCreditControlAnswer(CreditControlAnswerInfo response) {
 
         CreditControlAnswer answer = new CreditControlAnswer();
 

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/data/grpc/GrpcDataSource.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/data/grpc/GrpcDataSource.java
@@ -100,9 +100,8 @@ public class GrpcDataSource implements DataSource {
             try {
                 CreditControlRequestInfo.Builder builder = CreditControlRequestInfo.newBuilder();
                 builder.setType(getRequestType(context));
-                int index = 0;
                 for (MultipleServiceCreditControl mscc : context.getCreditControlRequest().getMultipleServiceCreditControls()) {
-                    builder.setMscc(index++, com.telenordigital.prime.ocs.MultipleServiceCreditControl.newBuilder()
+                    builder.addMscc(com.telenordigital.prime.ocs.MultipleServiceCreditControl.newBuilder()
                             .setRequested(ReguestedServiceUnit.newBuilder()
                                     .setInputOctets(0L)
                                     .setOutputOctetes(0L)

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/data/grpc/GrpcDataSource.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/data/grpc/GrpcDataSource.java
@@ -2,21 +2,19 @@ package com.telenordigital.ocsgw.data.grpc;
 
 import com.telenordigital.ocsgw.diameter.*;
 import com.telenordigital.ocsgw.data.DataSource;
-import com.telenordigital.prime.ocs.FetchDataBucketInfo;
-import com.telenordigital.prime.ocs.OcsServiceGrpc;
-import com.telenordigital.prime.ocs.ReturnUnusedDataRequest;
-import com.telenordigital.prime.ocs.ReturnUnusedDataResponse;
+import com.telenordigital.ocsgw.diameter.CreditControlAnswer;
+import com.telenordigital.ocsgw.diameter.MultipleServiceCreditControl;
+import com.telenordigital.prime.ocs.*;
+import com.telenordigital.prime.ocs.PsInformation;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import org.jdiameter.api.cca.ServerCCASession;
+import org.jdiameter.api.cca.events.JCreditControlRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * Uses Grpc to fetch data remotely
@@ -28,9 +26,7 @@ public class GrpcDataSource implements DataSource {
 
     private final OcsServiceGrpc.OcsServiceStub ocsServiceStub;
 
-    private StreamObserver<FetchDataBucketInfo> fetchDataBucketRequests;
-
-    private StreamObserver<ReturnUnusedDataRequest> returnUnusedDataRequests;
+    private StreamObserver<CreditControlRequestInfo> creditControlRequest;
 
     private static final int MAX_ENTRIES = 300;
     private final LinkedHashMap<String, CreditControlContext> ccrMap = new LinkedHashMap<String, CreditControlContext>(MAX_ENTRIES, .75F) {
@@ -70,80 +66,67 @@ public class GrpcDataSource implements DataSource {
     @Override
     public void init() {
 
-        LOG.info("Init was called");
-
-        fetchDataBucketRequests =
-                ocsServiceStub.fetchDataBucket(
-                        new AbstactObserver<FetchDataBucketInfo>() {
-                            public void onNext(FetchDataBucketInfo response) {
-                                try {
-                                    LOG.info("[<<] Received data bucket of " + response.getBytes() + " bytes for " + response.getMsisdn());
-                                    final CreditControlContext ccrContext = ccrMap.remove(response.getRequestId());
-                                    if (ccrContext != null) {
-                                        final ServerCCASession session = ccrContext.getSession();
-                                        if (session != null) {
-                                            CreditControlAnswer answer = createCreditControlAnswer(ccrContext, response);
-                                            ccrContext.sendCreditControlAnswer(answer);
-                                        } else {
-                                            LOG.warn("No stored CCR or Session for " + response.getRequestId());
-                                        }
-                                    } else {
-                                        LOG.warn("Missing CreditControlContext for req id " + response.getRequestId());
-                                    }
-                                } catch (Exception e) {
-                                    LOG.error("fetchDataBucket failed ", e);
-                                }
-                            }
-                        });
-
-        returnUnusedDataRequests = ocsServiceStub.returnUnusedData(
-                new AbstactObserver<ReturnUnusedDataResponse>() {
-                    public void onNext(ReturnUnusedDataResponse response) {
+        creditControlRequest = ocsServiceStub.creditControlRequest(
+                new AbstactObserver<CreditControlAnswerInfo>() {
+                    public void onNext(CreditControlAnswerInfo answer) {
                         try {
-                            System.out.println("[<<] Returned data bucket for " + response.getMsisdn());
+                            LOG.info("[<<] Received data bucket for " + answer.getMsisdn());
+                            final CreditControlContext ccrContext = ccrMap.remove(answer.getRequestId());
+                            if (ccrContext != null) {
+                                final ServerCCASession session = ccrContext.getSession();
+                                if (session != null) {
+                                    CreditControlAnswer cca = createCreditControlAnswer(ccrContext, answer);
+                                    ccrContext.sendCreditControlAnswer(cca);
+                                } else {
+                                    LOG.warn("No stored CCR or Session for " + answer.getRequestId());
+                                }
+                            } else {
+                                LOG.warn("Missing CreditControlContext for req id " + answer.getRequestId());
+                            }
                         } catch (Exception e) {
-                            LOG.error("returnUnusedData failed ", e);
+                            LOG.error("fetchDataBucket failed ", e);
                         }
                     }
                 });
-
     }
 
     @Override
-    public void handleRequest(CreditControlContext context) {
-
-        switch (context.getOriginalCreditControlRequest().getRequestTypeAVPValue()) {
-
-            case RequestType.INITIAL_REQUEST:
-                handleInitialRequest(context);
-                break;
-            case RequestType.UPDATE_REQUEST:
-                handleUpdateRequest(context);
-                break;
-            case RequestType.TERMINATION_REQUEST:
-                handleTerminationRequest(context);
-                break;
-            default:
-                LOG.info("Unhandled forward request");
-                break;
-        }
-    }
-
-    private void handleInitialRequest(final CreditControlContext context) {
-        // CCR-Init is handled in same way as Update
-        handleUpdateRequest(context);
-    }
-
-    private void handleUpdateRequest(final CreditControlContext context) {
+    public void handleRequest(final CreditControlContext context) {
         final String requestId = UUID.randomUUID().toString();
         ccrMap.put(requestId, context);
         LOG.info("[>>] Requesting bytes for {}", context.getCreditControlRequest().getMsisdn());
-        if (fetchDataBucketRequests != null) {
+
+        if (creditControlRequest != null) {
             try {
-                fetchDataBucketRequests.onNext(FetchDataBucketInfo.newBuilder()
-                        .setMsisdn(context.getCreditControlRequest().getMsisdn())
-                        .setBytes(context.getCreditControlRequest().getRequestedUnits()) // ToDo: this should correspond to a the correct MSCC
+                CreditControlRequestInfo.Builder builder = CreditControlRequestInfo.newBuilder();
+                builder.setType(getRequestType(context));
+                int index = 0;
+                for (MultipleServiceCreditControl mscc : context.getCreditControlRequest().getMultipleServiceCreditControls()) {
+                    builder.setMscc(index++, com.telenordigital.prime.ocs.MultipleServiceCreditControl.newBuilder()
+                            .setRequested(ReguestedServiceUnit.newBuilder()
+                                    .setInputOctets(0L)
+                                    .setOutputOctetes(0L)
+                                    .setTotalOctets(mscc.getRequestedUnits())
+                                    .build())
+                            .setUsed(UsedServiceUnit.newBuilder()
+                                    .setInputOctets(mscc.getUsedUnitsInput())
+                                    .setOutputOctetes(mscc.getUsedUnitsOutput())
+                                    .setTotalOctets(mscc.getUsedUnitsTotal())
+                                    .build())
+                            .setRatingGroup(mscc.getRatingGroup())
+                            .setServiceIdentifier(mscc.getServiceIdentifier())
+                    );
+                }
+                creditControlRequest.onNext(builder
                         .setRequestId(requestId)
+                        .setMsisdn(context.getCreditControlRequest().getMsisdn())
+                        .setImsi(context.getCreditControlRequest().getImsi())
+                        .setServiceInformation(
+                                ServiceInfo.newBuilder().setPsInformation(
+                                        PsInformation.newBuilder()
+                                                .setCalledStationId(context.getCreditControlRequest().getServiceInformation().getPsInformation().getCalledStationId())
+                                                .setSgsnMccMnc(context.getCreditControlRequest().getServiceInformation().getPsInformation().getSgsnMncMcc())
+                                ).build())
                         .build());
             } catch (Exception e) {
                 LOG.error("What just happened", e);
@@ -153,39 +136,62 @@ public class GrpcDataSource implements DataSource {
         }
     }
 
-    private void handleTerminationRequest(final CreditControlContext context) {
-        // For terminate we do not need to wait for remote end before we send CCA back (no reservation)
-        if (returnUnusedDataRequests != null) {
-            returnUnusedDataRequests.onNext(ReturnUnusedDataRequest.newBuilder()
-                    .setMsisdn(context.getCreditControlRequest().getMsisdn())
-                    .setBytes(1L) // ToDo : Fix proper. We have Used-Service-Unit not unused.
-                    .build());
-        } else {
-            LOG.warn("[!!] fetchDataBucketRequests is null");
+    private CreditControlRequestType getRequestType(CreditControlContext context) {
+        CreditControlRequestType type = CreditControlRequestType.NONE;
+        switch (context.getOriginalCreditControlRequest().getRequestTypeAVPValue()) {
+            case RequestType.INITIAL_REQUEST:
+                type = CreditControlRequestType.INITIAL_REQUEST;
+                break;
+            case RequestType.UPDATE_REQUEST:
+                type = CreditControlRequestType.UPDATE_REQUEST;
+                break;
+            case RequestType.TERMINATION_REQUEST:
+                type = CreditControlRequestType.TERMINATION_REQUEST;
+                break;
+            case RequestType.EVENT_REQUEST:
+                type = CreditControlRequestType.EVENT_REQUEST;
+                break;
+            default:
+                LOG.warn("Unknown request type");
+                break;
         }
-
-        context.sendCreditControlAnswer(createCreditControlAnswer(context, null));
+        return type;
     }
 
-    private CreditControlAnswer createCreditControlAnswer(CreditControlContext context, FetchDataBucketInfo response) {
-
-        // ToDo: Update with info in reply, this is just a temporary solution where we threat all mscc the same.
+    private CreditControlAnswer createCreditControlAnswer(CreditControlContext context, CreditControlAnswerInfo response) {
 
         CreditControlRequest request = context.getCreditControlRequest();
         CreditControlAnswer answer = new CreditControlAnswer();
 
-        final LinkedList<MultipleServiceCreditControl> multipleServiceCreditControls = request.getMultipleServiceCreditControls();
-
-        for (MultipleServiceCreditControl mscc : multipleServiceCreditControls) {
-            if (response != null) {
-                mscc.setGrantedServiceUnit(response.getBytes());
-            } else {
-                mscc.setGrantedServiceUnit(0L);
-            }
+        if (response == null) {
+            LOG.error("Empty CreditControlAnswerInfo received");
+            return answer;
         }
 
+        final LinkedList<MultipleServiceCreditControl> multipleServiceCreditControls = new LinkedList<>();
+        for (com.telenordigital.prime.ocs.MultipleServiceCreditControl mscc : response.getMsccList() ) {
+            multipleServiceCreditControls.add(convertMSCC(mscc));
+        }
         answer.setMultipleServiceCreditControls(multipleServiceCreditControls);
 
         return answer;
+    }
+
+    private MultipleServiceCreditControl convertMSCC(com.telenordigital.prime.ocs.MultipleServiceCreditControl msccGRPC) {
+        MultipleServiceCreditControl mscc = new MultipleServiceCreditControl();
+        mscc.setRatingGroup(msccGRPC.getRatingGroup());
+        mscc.setServiceIdentifier(msccGRPC.getServiceIdentifier());
+        mscc.setGrantedServiceUnit(msccGRPC.getGranted().getTotalOctets());
+        mscc.setValidityTime(msccGRPC.getValidityTime());
+        mscc.setFinalUnitIndication(convertFinalUnitIndication(msccGRPC.getFinalUnitIndication()));
+        return mscc;
+    }
+
+    private com.telenordigital.ocsgw.diameter.FinalUnitIndication convertFinalUnitIndication(com.telenordigital.prime.ocs.FinalUnitIndication fuiGrpc) {
+        com.telenordigital.ocsgw.diameter.FinalUnitIndication finalUnitIndication = new com.telenordigital.ocsgw.diameter.FinalUnitIndication();
+        finalUnitIndication.setFinalUnitAction(fuiGrpc.getFinalUnitAction().getNumber());
+        //finalUnitIndication.setRestrictionFilterRule(); FixMe
+        finalUnitIndication.setFilterId(new LinkedList(Arrays.asList(fuiGrpc.getFilterIdList().toArray())));
+        return finalUnitIndication;
     }
 }

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/data/local/LocalDataSource.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/data/local/LocalDataSource.java
@@ -2,6 +2,7 @@ package com.telenordigital.ocsgw.data.local;
 
 import com.telenordigital.ocsgw.diameter.*;
 import com.telenordigital.ocsgw.data.DataSource;
+import com.telenordigital.prime.ocs.CreditControlRequestType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +35,14 @@ public class LocalDataSource implements DataSource {
         final LinkedList<MultipleServiceCreditControl> multipleServiceCreditControls = context.getCreditControlRequest().getMultipleServiceCreditControls();
 
         for (MultipleServiceCreditControl mscc : multipleServiceCreditControls) {
+
             mscc.setGrantedServiceUnit(mscc.getRequestedUnits());
+
+            if (context.getOriginalCreditControlRequest().getRequestTypeAVPValue() == CreditControlRequestType.TERMINATION_REQUEST.getNumber()) {
+                FinalUnitIndication finalUnitIndication = new FinalUnitIndication();
+                finalUnitIndication.setFinalUnitAction(FinalUnitAction.TERMINATE);
+                mscc.setFinalUnitIndication(finalUnitIndication);
+            }
         }
 
         answer.setMultipleServiceCreditControls(multipleServiceCreditControls);

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/CreditControlContext.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/CreditControlContext.java
@@ -103,8 +103,7 @@ public class CreditControlContext {
                 }
 
                 answerMSCC.addAvp(Avp.RESULT_CODE, resultCode, true, false);
-                // Validity is set to 24 hours
-                answerMSCC.addAvp(Avp.VALIDITY_TIME, 86400, true, false);
+                answerMSCC.addAvp(Avp.VALIDITY_TIME, mscc.getValidityTime(), true, false);
             }
             LOG.info("Credit-Control-Answer");
             DiameterUtilities.printAvps(ccaAvps);

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/CreditControlContext.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/CreditControlContext.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
+import java.util.Optional;
 
 public class CreditControlContext {
 
@@ -94,10 +95,7 @@ public class CreditControlContext {
                     gsuAvp.addAvp(Avp.CC_TOTAL_OCTETS, 0L, true, false);
                     gsuAvp.addAvp(Avp.CC_SERVICE_SPECIFIC_UNITS, 0L, true, false);
 
-                    // There seems to be a possibility to do some whitelisting here by using RESTRICT_ACCESS
-                    // We should have a look at: https://tools.ietf.org/html/rfc4006#section-5.6.3
-                    AvpSet finalUnitIndication = answerMSCC.addGroupedAvp(Avp.FINAL_UNIT_INDICATION, true, false);
-                    finalUnitIndication.addAvp(Avp.FINAL_UNIT_ACTION, FinalUnitAction.TERMINATE, true, false);
+                    addFinalUnitAction(answerMSCC, mscc);
                 } else {
                     gsuAvp.addAvp(Avp.CC_TOTAL_OCTETS, mscc.getGrantedServiceUnit(), true, false);
                 }
@@ -112,5 +110,19 @@ public class CreditControlContext {
             LOG.error("Failed to convert to Credit-Control-Answer", e);
         }
         return answer;
+    }
+
+    private void addFinalUnitAction(AvpSet answerMSCC, MultipleServiceCreditControl mscc) {
+
+        // There seems to be a possibility to do some whitelisting here by using RESTRICT_ACCESS
+        // We should have a look at: https://tools.ietf.org/html/rfc4006#section-5.6.3
+
+        Optional<FinalUnitIndication> finalUnitIndicationReply = Optional.ofNullable(mscc.getFinalUnitIndication());
+        if (finalUnitIndicationReply.isPresent()) {
+            AvpSet finalUnitIndication = answerMSCC.addGroupedAvp(Avp.FINAL_UNIT_INDICATION, true, false);
+            finalUnitIndication.addAvp(Avp.FINAL_UNIT_ACTION, mscc.getFinalUnitIndication().getFinalUnitAction(), true, false);
+        }
+
+        //ToDo : Add support for the rest of the Final-Unit-Action
     }
 }

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/CreditControlRequest.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/CreditControlRequest.java
@@ -20,8 +20,8 @@ public class CreditControlRequest {
     private final LinkedList<MultipleServiceCreditControl> multipleServiceCreditControls = new LinkedList<>();
     private final ServiceInformation serviceInformation = new ServiceInformation();
     private final UserEquipmentInfo userEquipmentInfo = new UserEquipmentInfo();
-    private String msisdn = null;
-    private String imsi = null;
+    private String msisdn = "";
+    private String imsi = "";
     private Avp ccRequestType;
     private Avp ccRequestNumber;
 

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/FinalUnitAction.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/FinalUnitAction.java
@@ -2,7 +2,6 @@ package com.telenordigital.ocsgw.diameter;
 
 // https://tools.ietf.org/html/rfc4006#page-71
 
-@SuppressWarnings("unused")
 public class FinalUnitAction {
     public static final int TERMINATE = 0;
     public static final int REDIRECT = 1;

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/FinalUnitIndication.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/FinalUnitIndication.java
@@ -1,0 +1,44 @@
+package com.telenordigital.ocsgw.diameter;
+
+import java.util.LinkedList;
+
+public class FinalUnitIndication {
+
+
+    private int finalUnitAction = FinalUnitAction.TERMINATE;
+    private LinkedList<IPFilterRule> restrictionFilterRule = new LinkedList<>();
+    private LinkedList<String> filterId = new LinkedList<>();
+    private RedirectServer redirectServer = new RedirectServer();
+
+    public int getFinalUnitAction() {
+        return finalUnitAction;
+    }
+
+    public void setFinalUnitAction(int finalUnitAction) {
+        this.finalUnitAction = finalUnitAction;
+    }
+
+    public LinkedList<IPFilterRule> getRestrictionFilterRule() {
+        return restrictionFilterRule;
+    }
+
+    public void setRestrictionFilterRule(LinkedList<IPFilterRule> restrictionFilterRule) {
+        this.restrictionFilterRule = restrictionFilterRule;
+    }
+
+    public LinkedList<String> getFilterId() {
+        return filterId;
+    }
+
+    public void setFilterId(LinkedList<String> filterId) {
+        this.filterId = filterId;
+    }
+
+    public RedirectServer getRedirectServer() {
+        return redirectServer;
+    }
+
+    public void setRedirectServer(RedirectServer redirectServer) {
+        this.redirectServer = redirectServer;
+    }
+}

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/IPFilterRule.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/IPFilterRule.java
@@ -12,8 +12,8 @@ enum Direction {
 
 
 public class IPFilterRule {
-    Action action;
-    Direction direction;
-    String proto;
-    String host;
+    private Action action;
+    private Direction direction;
+    private String proto;
+    private String host;
 }

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/IPFilterRule.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/IPFilterRule.java
@@ -1,0 +1,19 @@
+package com.telenordigital.ocsgw.diameter;
+
+enum Action {
+    PERMIT,
+    DENY
+}
+
+enum Direction {
+    IN,
+    OUT
+}
+
+
+public class IPFilterRule {
+    Action action;
+    Direction direction;
+    String proto;
+    String host;
+}

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/MultipleServiceCreditControl.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/MultipleServiceCreditControl.java
@@ -2,6 +2,7 @@ package com.telenordigital.ocsgw.diameter;
 
 // https://tools.ietf.org/html/rfc4006#section-8.16
 
+import com.telenordigital.ocsgw.diameter.FinalUnitIndication;
 import org.jdiameter.api.Avp;
 import org.jdiameter.api.AvpDataException;
 import org.jdiameter.api.AvpSet;
@@ -11,17 +12,19 @@ import org.slf4j.LoggerFactory;
 import java.util.Optional;
 
 public class MultipleServiceCreditControl {
-    private long ratingGroup = -1;
+    private int ratingGroup = -1;
     private int serviceIdentifier = -1;
 
-    private long requestedUnits = 0;
-    private long usedUnitsTotal = 0;
-    private long usedUnitsInput = 0;
-    private long usedUnitsOutput = 0;
-    private long reservedUnits = 0;
-    private long grantedServiceUnit = 0;
+    private long requestedUnits = 0L;
+    private long usedUnitsTotal = 0L;
+    private long usedUnitsInput = 0L;
+    private long usedUnitsOutput = 0L;
+    private long reservedUnits = 0L;
+    private long grantedServiceUnit = 0L;
+    private int validityTime = 86400;
+    private FinalUnitIndication finalUnitIndication;
 
-    private static final Logger logger = LoggerFactory.getLogger(MultipleServiceCreditControl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MultipleServiceCreditControl.class);
 
 
     public long getRequestedUnits() {
@@ -44,8 +47,16 @@ public class MultipleServiceCreditControl {
         return usedUnitsOutput;
     }
 
-    public long getRatingGroup() {
+    public int getRatingGroup() {
         return ratingGroup;
+    }
+
+    public void setRatingGroup(int ratingGroup) {
+        this.ratingGroup = ratingGroup;
+    }
+
+    public void setServiceIdentifier(int serviceIdentifier) {
+        this.serviceIdentifier = serviceIdentifier;
     }
 
     public int getServiceIdentifier() {
@@ -55,6 +66,15 @@ public class MultipleServiceCreditControl {
     public long getGrantedServiceUnit() {
         return grantedServiceUnit;
     }
+
+    public int getValidityTime() {
+        return validityTime;
+    }
+
+    public void setValidityTime(int validityTime) {
+        this.validityTime = validityTime;
+    }
+
 
     public void parseAvps(AvpSet serviceControl) {
         try {
@@ -75,7 +95,7 @@ public class MultipleServiceCreditControl {
 
             parseUsedServiceUnit(serviceControl);
         } catch (AvpDataException e) {
-            logger.warn("Failed to parse Multiple-Service-Credit-Control", e);
+            LOG.warn("Failed to parse Multiple-Service-Credit-Control", e);
         }
     }
 
@@ -103,7 +123,7 @@ public class MultipleServiceCreditControl {
                 }
             }
         } catch (AvpDataException e) {
-            logger.warn("Failed to parse Used-Service-Unit", e);
+            LOG.warn("Failed to parse Used-Service-Unit", e);
         }
     }
 
@@ -117,11 +137,16 @@ public class MultipleServiceCreditControl {
                 "; usedUnitsOutput=" + usedUnitsOutput +
                 "; Rating-Group=" + ratingGroup +
                 "; Service-Identifier=" + serviceIdentifier +
-                "; Granted-Service-Unit" +
+                "; Granted-Service-Unit" + grantedServiceUnit +
+                "; Validity-Time" + validityTime +
                 "]";
     }
 
     public void setGrantedServiceUnit(long bytes) {
         this.grantedServiceUnit = bytes;
+    }
+
+    public void setFinalUnitIndication(com.telenordigital.ocsgw.diameter.FinalUnitIndication finalUnitIndication) {
+        this.finalUnitIndication = finalUnitIndication;
     }
 }

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/MultipleServiceCreditControl.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/MultipleServiceCreditControl.java
@@ -149,4 +149,8 @@ public class MultipleServiceCreditControl {
     public void setFinalUnitIndication(com.telenordigital.ocsgw.diameter.FinalUnitIndication finalUnitIndication) {
         this.finalUnitIndication = finalUnitIndication;
     }
+
+    public com.telenordigital.ocsgw.diameter.FinalUnitIndication getFinalUnitIndication() {
+        return this.finalUnitIndication;
+    }
 }

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/MultipleServiceCreditControl.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/MultipleServiceCreditControl.java
@@ -2,7 +2,6 @@ package com.telenordigital.ocsgw.diameter;
 
 // https://tools.ietf.org/html/rfc4006#section-8.16
 
-import com.telenordigital.ocsgw.diameter.FinalUnitIndication;
 import org.jdiameter.api.Avp;
 import org.jdiameter.api.AvpDataException;
 import org.jdiameter.api.AvpSet;
@@ -19,7 +18,6 @@ public class MultipleServiceCreditControl {
     private long usedUnitsTotal = 0L;
     private long usedUnitsInput = 0L;
     private long usedUnitsOutput = 0L;
-    private long reservedUnits = 0L;
     private long grantedServiceUnit = 0L;
     private int validityTime = 86400;
     private FinalUnitIndication finalUnitIndication;
@@ -29,10 +27,6 @@ public class MultipleServiceCreditControl {
 
     public long getRequestedUnits() {
         return requestedUnits;
-    }
-
-    public long getReservedUnits() {
-        return reservedUnits;
     }
 
     public long getUsedUnitsTotal() {
@@ -131,7 +125,6 @@ public class MultipleServiceCreditControl {
     public String toString() {
         return "MultipleServiceCreditControl[" +
                 "; Requested-Service-Unit=" + requestedUnits +
-                "; Reserved-Service-Unit=" + reservedUnits +
                 "; usedUnitsTotal=" + usedUnitsTotal +
                 "; usedUnitsInput=" + usedUnitsInput +
                 "; usedUnitsOutput=" + usedUnitsOutput +

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/PsInformation.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/PsInformation.java
@@ -112,9 +112,9 @@ public class PsInformation {
 
     public void parseAvps(AvpSet psInformationAvps) {
         try {
-            Optional<byte[]> chargingId = Optional.ofNullable(psInformationAvps.getAvp(Avp.TGPP_CHARGING_ID).getOctetString());
+            Optional<Avp> chargingId = Optional.ofNullable(psInformationAvps.getAvp(Avp.TGPP_CHARGING_ID));
             if (chargingId.isPresent()) {
-                this.chargingId = chargingId.get();
+                this.chargingId = chargingId.get().getOctetString();
             }
             Optional<Avp> pdpType = Optional.ofNullable(psInformationAvps.getAvp(Avp.TGPP_PDP_TYPE));
             if (pdpType.isPresent()) {

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/RedirectServer.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/RedirectServer.java
@@ -11,5 +11,5 @@ enum RedirectAddressType {
 
 public class RedirectServer {
     private RedirectAddressType redirectAddressType;
-    String redirectServerAddress;
+    private String redirectServerAddress;
 }

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/RedirectServer.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/RedirectServer.java
@@ -1,0 +1,15 @@
+package com.telenordigital.ocsgw.diameter;
+
+
+enum RedirectAddressType {
+    IPV4_ADDRESS,
+    IPV6_ADDRESS,
+    URL,
+    SIP_URL
+}
+
+
+public class RedirectServer {
+    private RedirectAddressType redirectAddressType;
+    String redirectServerAddress;
+}

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/ServiceInformation.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/diameter/ServiceInformation.java
@@ -9,11 +9,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
-class ServiceInformation {
+public class ServiceInformation {
     private static final Logger LOG = LoggerFactory.getLogger(ServiceInformation.class);
     private final PsInformation psInformation = new PsInformation();
 
-    public PsInformation getPsinformation() {
+    public PsInformation getPsInformation() {
         return psInformation;
     }
 

--- a/ocsgw/src/main/java/com/telenordigital/ocsgw/utils/DiameterUtilities.java
+++ b/ocsgw/src/main/java/com/telenordigital/ocsgw/utils/DiameterUtilities.java
@@ -38,7 +38,7 @@ public class DiameterUtilities {
     }
 
     private static Object getAvpValue(Avp avp) {
-        Object avpValue = null;
+        Object avpValue;
         try {
             String avpType = AVP_DICTIONARY.getAvp(avp.getCode(), avp.getVendorId()).getType();
 

--- a/ocsgw/src/test/java/com/telenordigital/ocsgw/OcsApplicationTest.java
+++ b/ocsgw/src/test/java/com/telenordigital/ocsgw/OcsApplicationTest.java
@@ -105,6 +105,7 @@ class OcsApplicationTest {
             Avp resultMSCC = resultAvps.getAvp(Avp.MULTIPLE_SERVICES_CREDIT_CONTROL);
             assertEquals(2001L, resultMSCC.getGrouped().getAvp(Avp.RESULT_CODE).getInteger32());
             assertEquals(1, resultMSCC.getGrouped().getAvp(Avp.SERVICE_IDENTIFIER_CCA).getInteger32());
+            assertEquals(10, resultMSCC.getGrouped().getAvp(Avp.RATING_GROUP).getInteger32());
             Avp granted = resultMSCC.getGrouped().getAvp(Avp.GRANTED_SERVICE_UNIT);
             assertEquals(500000L, granted.getGrouped().getAvp(Avp.CC_TOTAL_OCTETS).getUnsigned64());
         } catch (AvpDataException e) {

--- a/ocsgw/src/test/java/com/telenordigital/ocsgw/OcsApplicationTest.java
+++ b/ocsgw/src/test/java/com/telenordigital/ocsgw/OcsApplicationTest.java
@@ -44,7 +44,7 @@ class OcsApplicationTest {
     private TestClient client;
 
     // The same OcsApplication will be used in all test cases
-    private OcsApplication application = new OcsApplication();
+    private final OcsApplication application = new OcsApplication();
     private static boolean applicationStarted = false;
 
     @BeforeEach
@@ -271,8 +271,6 @@ class OcsApplicationTest {
         byte[] ratTypeBytes = new byte[] {06};
         String ratType = new String(ratTypeBytes, "UTF-8");
         psInformation.addAvp(Avp.TGPP_RAT_TYPE, ratType , VENDOR_ID_3GPP, true, false, true);
-
-        char[] ch = {0x82,0x42,0xf2,0x10,0x78,0xb5,0x42,0xf2,0x10,0x01,0x03,0xc7,0x03};
 
         String s = "8242f21078b542f2100103c703";
 

--- a/ocsgw/src/test/java/com/telenordigital/ocsgw/OcsApplicationTest.java
+++ b/ocsgw/src/test/java/com/telenordigital/ocsgw/OcsApplicationTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertEquals;
 
 
 /**
- *  Tests for the OcsAppliaction. This will use a TestClient to
+ *  Tests for the OcsApplication. This will use a TestClient to
  *  actually send Diameter traffic on localhost to the OcsApplication.
  */
 
@@ -218,7 +218,7 @@ class OcsApplicationTest {
 
     // Currently not used in testing
     @DisplayName("Service-Information Credit-Control-Request Init")
-    public void serviceInformationCreditControlRequestInit() {
+    public void serviceInformationCreditControlRequestInit() throws UnsupportedEncodingException {
 
         Request request = client.getSession().createRequest(
                 commandCode,
@@ -263,11 +263,20 @@ class OcsApplicationTest {
         psInformation.addAvp(Avp.TGPP_SESSION_STOP_INDICATOR, "\377", VENDOR_ID_3GPP, true, false, false);
         psInformation.addAvp(Avp.TGPP_SELECTION_MODE, "0", VENDOR_ID_3GPP, true, false, false);
         psInformation.addAvp(Avp.TGPP_CHARGING_CHARACTERISTICS, "0800", VENDOR_ID_3GPP, true, false, true);
-        psInformation.addAvp(Avp.GPP_SGSN_MCC_MNC, "24201", false);
-        psInformation.addAvp(Avp.TGPP_MS_TIMEZONE, "4000", VENDOR_ID_3GPP, true, false, true);
+        psInformation.addAvp(Avp.GPP_SGSN_MCC_MNC, "24201", VENDOR_ID_3GPP, true, false, false);
+        byte[] timeZoneBytes = new byte[] {64, 00};
+        String timeZone = new String(timeZoneBytes, "UTF-8");
+        psInformation.addAvp(Avp.TGPP_MS_TIMEZONE, timeZone, VENDOR_ID_3GPP, true, false, true);
         psInformation.addAvp(Avp.CHARGING_RULE_BASE_NAME, "RB1", VENDOR_ID_3GPP, true, false, false);
-        psInformation.addAvp(Avp.TGPP_RAT_TYPE, "6", VENDOR_ID_3GPP, true, false, true);
-        psInformation.addAvp(Avp.GPP_USER_LOCATION_INFO, "8242f21078b542f2100103c703",VENDOR_ID_3GPP, true, false, false);
+        byte[] ratTypeBytes = new byte[] {06};
+        String ratType = new String(ratTypeBytes, "UTF-8");
+        psInformation.addAvp(Avp.TGPP_RAT_TYPE, ratType , VENDOR_ID_3GPP, true, false, true);
+
+        char[] ch = {0x82,0x42,0xf2,0x10,0x78,0xb5,0x42,0xf2,0x10,0x01,0x03,0xc7,0x03};
+
+        String s = "8242f21078b542f2100103c703";
+
+        psInformation.addAvp(Avp.GPP_USER_LOCATION_INFO, new String(s.getBytes(), "UTF-8"), VENDOR_ID_3GPP, true, false, false);
 
         JCreditControlRequest ccr = new JCreditControlRequestImpl(request);
 

--- a/prime/README.md
+++ b/prime/README.md
@@ -5,7 +5,7 @@
 ## Interfaces
 
 * Subscriber (End-user and/or CRM)
-* OCS (Online Charging System) Gateway (towards Packet gateway (PGw))
+* OCS (Online Charging System) Gateway (towards Packet gateway (P-GW))
 
 
 
@@ -16,21 +16,15 @@
 * Get available Data balance
 
 ### OCS API
-* Fetch Data bucket
+* CreditControlRequest
 
 
-    PGw requests Data buckets (of approx 100 MB) for a subscriber.
+    P-GW requests Data buckets (of approx 100 MB) for a subscriber.
     This request is made before its current bucket is about to be exhausted.
     This request has very high throughput and low latency requirement.
-    Low latency is required because if the PGw does not receives 
+    Low latency is required because if the P-GW does not receives 
     a response in time before the current bucket is expired, it disconnects/throttles
     data of the subscriber.
-
-* Return Unused Data
-
-
-    When subscriber disables its data connection, unused data from the prior requested 
-    buckets is returned back. 
 
 * Activate after Data top up
 
@@ -45,9 +39,8 @@
 
 | Message Type              | Producer   | Handler  | Next Handler                      |
 | ---                       | ---        | ---      | ---                               |
-| FETCH_DATA_BUCKET         | OcsService | OcsState | OcsService, _(maybe) Subscriber_  |
-| RETURN_UNUSED_DATA_BUCKET | OcsService | OcsState | OcsService, Subscriber            |
+| CREDIT_CONTROL_REQUEST    | OcsService | OcsState | OcsService, _(maybe) Subscriber_  |
+| RELEASE_RESERVED_BUCKET   | OcsService | OcsState | OcsService, Subscriber            |
 | TOPUP_DATA_BUNDLE_BALANCE | Subscriber | OcsState | OcsService (activate), Subscriber |
 | GET_DATA_BUNDLE_BALANCE   | Subscriber | OcsState | Subscriber                        |
 
-     

--- a/prime/build.gradle
+++ b/prime/build.gradle
@@ -85,6 +85,7 @@ check.dependsOn jacocoTestReport
 test {
     testLogging {
         exceptionFormat = 'full'
+        events "PASSED", "FAILED", "SKIPPED"
     }
 }
 

--- a/prime/build.gradle
+++ b/prime/build.gradle
@@ -83,6 +83,12 @@ jacocoTestReport {
 
 check.dependsOn jacocoTestReport
 
+test {
+    testLogging {
+        exceptionFormat = 'full'
+    }
+}
+
 idea {
     module {
         testSourceDirs += file('src/integration-tests/java')

--- a/prime/src/integration-tests/java/com/telenordigital/prime/ocs/OcsTest.java
+++ b/prime/src/integration-tests/java/com/telenordigital/prime/ocs/OcsTest.java
@@ -91,7 +91,7 @@ public final class OcsTest {
         ocsServer = new OcsServer(PORT, ocsService.asOcsServiceImplBase());
 
         final OcsState ocsState = new OcsState();
-        ocsState.addDataBytes(MSISDN, NO_OF_BYTES_TO_ADD);
+        ocsState.addDataBundleBytes(MSISDN, NO_OF_BYTES_TO_ADD);
 
         // Events flow:
         //      Producer:(OcsService, Subscriber)

--- a/prime/src/main/java/com/telenordigital/prime/PrimeApplication.java
+++ b/prime/src/main/java/com/telenordigital/prime/PrimeApplication.java
@@ -46,8 +46,8 @@ public final class PrimeApplication extends Application<PrimeConfiguration> {
         final EventProcessorConfiguration eventProcessorConfig =
                 primeConfiguration.getEventProcessorConfig();
 
-        // XXX Badly named class with less than clarly specified intent.
-        //     What it it's doing is to glue things together and thus
+        // XXX Badly named class with less than clearly specified intent.
+        //     What it's doing is to glue things together and thus
         //     concentrate coupling between other classes into this
         //     single class, but that isn't well documented yet.
         final EventListeners eventListeners = new EventListeners(ocsState);

--- a/prime/src/main/java/com/telenordigital/prime/analytics/DataConsumptionInfoPublisher.java
+++ b/prime/src/main/java/com/telenordigital/prime/analytics/DataConsumptionInfoPublisher.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 
-import static com.telenordigital.prime.disruptor.PrimeEventMessageType.FETCH_DATA_BUCKET;
+import static com.telenordigital.prime.disruptor.PrimeEventMessageType.CREDIT_CONTROL_REQUEST;
 
 /**
  * This class publishes the data consumption information events to the Google Cloud Pub/Sub.
@@ -60,13 +60,14 @@ public class DataConsumptionInfoPublisher implements EventHandler<PrimeEvent>, M
             final long sequence,
             final boolean endOfBatch) throws Exception {
 
-        if (event.getMessageType() != FETCH_DATA_BUCKET) {
+        if (event.getMessageType() != CREDIT_CONTROL_REQUEST) {
             return;
         }
 
+        // FiXMe : We only report the requested bucket. Should probably report the Used-Units instead
         final ByteString data = DataTrafficInfo.newBuilder()
                 .setMsisdn(event.getMsisdn())
-                .setBucketBytes(event.getBucketBytes())
+                .setBucketBytes(event.getRequestedBucketBytes())
                 .setBundleBytes(event.getBundleBytes())
                 .setTimestamp(Timestamps.fromMillis((Instant.now().toEpochMilli())))
                 .build()

--- a/prime/src/main/java/com/telenordigital/prime/disruptor/PrimeEvent.java
+++ b/prime/src/main/java/com/telenordigital/prime/disruptor/PrimeEvent.java
@@ -17,13 +17,22 @@ public final class PrimeEvent {
     private String msisdn;
 
     /**
-     *  Origin of word 'bucket' - PGw consumes data in `buckets` of 10 MB ~ 100 MB at a time
-     *  This field is used in...
-     *  1. Request to fetch bucket
-     *  2. Response of actual allowed bucket
-     *  3. Request to return unused bucket
+     *  Origin of word 'bucket' - P-GW consumes data in `buckets` of 10 MB ~ 100 MB at a time
+     *  This field is used in.
+     *  Request to reserve a new bucket of bytes
      */
-    private long bucketBytes;
+    private long requestedBucketBytes;
+
+    /**
+     *  Bytes that has been used from the bucket (previously reserved).
+     */
+    private long usedBucketBytes;
+
+
+    /**
+     *  Buckets that has been reserved from the bundle.
+     */
+    private long reservedBucketBytes;
 
     /**
      *  Origin of word 'bundle' - Subscriber buys a 'bundle' of units of data/airtime/validity etc.
@@ -44,23 +53,31 @@ public final class PrimeEvent {
 
     public void clear() {
         msisdn = null;
-        bucketBytes = 0;
+        requestedBucketBytes = 0;
+        usedBucketBytes = 0;
+        reservedBucketBytes = 0;
         bundleBytes = 0;
         ocsgwStreamId = null;
         ocsgwRequestId = null;
         messageType = null;
     }
 
+    //FixMe : We need to think about roaming!!!
+
     public void update(
             final PrimeEventMessageType messageType,
             final String msisdn,
-            final long bytes,
+            final long requestedBytes,
+            final long usedBytes,
+            final long reservedBucketBytes,
             final String ocsgwStreamId,
             final String ocsgwRequestId) {
-        this.setMessageType(messageType);
-        this.setMsisdn(msisdn);
-        this.setBucketBytes(bytes);
-        this.setOcsgwStreamId(ocsgwStreamId);
-        this.setOcsgwRequestId(ocsgwRequestId);
+        this.messageType = messageType;
+        this.msisdn = msisdn;
+        this.requestedBucketBytes = requestedBytes;
+        this.usedBucketBytes = usedBytes;
+        this.reservedBucketBytes = reservedBucketBytes;
+        this.ocsgwStreamId = ocsgwStreamId;
+        this.ocsgwRequestId = ocsgwRequestId;
     }
 }

--- a/prime/src/main/java/com/telenordigital/prime/disruptor/PrimeEvent.java
+++ b/prime/src/main/java/com/telenordigital/prime/disruptor/PrimeEvent.java
@@ -51,6 +51,16 @@ public final class PrimeEvent {
     private String ocsgwRequestId;
 
 
+    /**
+     * Service-Identifier is used to classify traffic
+     */
+    private int serviceIdentifier;
+
+    /**
+     * Rating-Group is used to classify traffic
+     */
+    private int ratingGroup;
+
     public void clear() {
         msisdn = null;
         requestedBucketBytes = 0;
@@ -59,6 +69,8 @@ public final class PrimeEvent {
         bundleBytes = 0;
         ocsgwStreamId = null;
         ocsgwRequestId = null;
+        serviceIdentifier = 0;
+        ratingGroup = 0;
         messageType = null;
     }
 
@@ -70,6 +82,8 @@ public final class PrimeEvent {
             final long requestedBytes,
             final long usedBytes,
             final long reservedBucketBytes,
+            final int serviceIdentifier,
+            final int ratingGroup,
             final String ocsgwStreamId,
             final String ocsgwRequestId) {
         this.messageType = messageType;
@@ -77,6 +91,8 @@ public final class PrimeEvent {
         this.requestedBucketBytes = requestedBytes;
         this.usedBucketBytes = usedBytes;
         this.reservedBucketBytes = reservedBucketBytes;
+        this.serviceIdentifier = serviceIdentifier;
+        this.ratingGroup = ratingGroup;
         this.ocsgwStreamId = ocsgwStreamId;
         this.ocsgwRequestId = ocsgwRequestId;
     }

--- a/prime/src/main/java/com/telenordigital/prime/disruptor/PrimeEventMessageType.java
+++ b/prime/src/main/java/com/telenordigital/prime/disruptor/PrimeEventMessageType.java
@@ -3,6 +3,6 @@ package com.telenordigital.prime.disruptor;
 public enum PrimeEventMessageType {
     GET_DATA_BUNDLE_BALANCE,
     TOPUP_DATA_BUNDLE_BALANCE,
-    FETCH_DATA_BUCKET,
-    RETURN_UNUSED_DATA_BUCKET
+    CREDIT_CONTROL_REQUEST,
+    RELEASE_RESERVED_BUCKET
 }

--- a/prime/src/main/java/com/telenordigital/prime/disruptor/PrimeEventProducer.java
+++ b/prime/src/main/java/com/telenordigital/prime/disruptor/PrimeEventProducer.java
@@ -55,6 +55,8 @@ public final class PrimeEventProducer {
             final long requestedBytes,
             final long usedBytes,
             final long reservedBytes,
+            final int serviceId,
+            final int ratingGroup,
             final String streamId,
             final String requestId) {
         processNextEventOnTheRingbuffer(event ->
@@ -63,6 +65,8 @@ public final class PrimeEventProducer {
                         requestedBytes,
                         usedBytes,
                         reservedBytes,
+                        serviceId,
+                        ratingGroup,
                         streamId,
                         requestId));
     }
@@ -73,6 +77,8 @@ public final class PrimeEventProducer {
         injectIntoRingbuffer(TOPUP_DATA_BUNDLE_BALANCE,
                 msisdn,
                 bytes,
+                0,
+                0,
                 0,
                 0,
                 null,
@@ -87,6 +93,8 @@ public final class PrimeEventProducer {
                 0,
                 0,
                 bytes,
+                0,
+                0,
                 null,
                 null
         );
@@ -101,6 +109,8 @@ public final class PrimeEventProducer {
                 request.getMscc(0).getRequested().getTotalOctets(),
                 request.getMscc(0).getUsed().getTotalOctets(),
                 0,
+                request.getMscc(0).getServiceIdentifier(),
+                request.getMscc(0).getRatingGroup(),
                 streamId,
                 request.getRequestId());
     }

--- a/prime/src/main/java/com/telenordigital/prime/events/EventProcessor.java
+++ b/prime/src/main/java/com/telenordigital/prime/events/EventProcessor.java
@@ -125,7 +125,7 @@ public final class EventProcessor implements EventHandler<PrimeEvent>, Managed {
             final boolean endOfBatch) throws Exception {
 
 
-        // FETCH_DATA_BUCKET is a high frequency operation. If we do want to
+        // CREDIT_CONTROL_REQUEST is a high frequency operation. If we do want to
         // include data balance updates from this event type, then we can
         // skip 'switch' stmt since we will do 'setRemainingByMsisdn' for all cases.
 
@@ -142,7 +142,7 @@ public final class EventProcessor implements EventHandler<PrimeEvent>, Managed {
         switch (event.getMessageType()) {
 
             // Continuous updates of data consumption. High frequency!
-            case FETCH_DATA_BUCKET:
+            case CREDIT_CONTROL_REQUEST:
 
             // response to my request, this is the new balance.
             case TOPUP_DATA_BUNDLE_BALANCE:

--- a/prime/src/main/java/com/telenordigital/prime/ocs/EventHandlerImpl.java
+++ b/prime/src/main/java/com/telenordigital/prime/ocs/EventHandlerImpl.java
@@ -59,8 +59,8 @@ final class EventHandlerImpl implements EventHandler<PrimeEvent> {
     }
 
     private void logEventPRocessing(final String msg, final PrimeEvent event) {
-        LOG.info("{} :: for MSISDN: {} of {} bytes with request id: {}",
-                msg, event.getMsisdn(), event.getRequestedBucketBytes(), event.getOcsgwRequestId());
+        LOG.info("{} :: for MSISDN: {} of {} requested bytes {} used bytes with request id: {}",
+                msg, event.getMsisdn(), event.getRequestedBucketBytes(), event.getUsedBucketBytes() ,event.getOcsgwRequestId());
     }
 
     private void handleCreditControlRequest(final PrimeEvent event) {
@@ -70,10 +70,12 @@ final class EventHandlerImpl implements EventHandler<PrimeEvent> {
         // FixMe: This assume we only have one MSCC
         try {
             final CreditControlAnswerInfo creditControlAnswer =
-                    CreditControlAnswerInfo.newBuilder().
-                            setMsisdn(event.getMsisdn()).
-                            addMscc(MultipleServiceCreditControl.newBuilder().setGranted(
-                                    GrantedServiceUnit.newBuilder().setTotalOctets(event.getReservedBucketBytes()).build())
+                    CreditControlAnswerInfo.newBuilder()
+                            .setMsisdn(event.getMsisdn())
+                            .addMscc(MultipleServiceCreditControl.newBuilder()
+                                    .setGranted(GrantedServiceUnit.newBuilder()
+                                            .setTotalOctets(event.getReservedBucketBytes())
+                                            .build())
                                     .setServiceIdentifier(event.getServiceIdentifier())
                                     .setRatingGroup(event.getRatingGroup())
                                     .setValidityTime(86400)

--- a/prime/src/main/java/com/telenordigital/prime/ocs/EventHandlerImpl.java
+++ b/prime/src/main/java/com/telenordigital/prime/ocs/EventHandlerImpl.java
@@ -76,6 +76,7 @@ final class EventHandlerImpl implements EventHandler<PrimeEvent> {
                                     GrantedServiceUnit.newBuilder().setTotalOctets(event.getReservedBucketBytes()).build())
                                     .setServiceIdentifier(event.getServiceIdentifier())
                                     .setRatingGroup(event.getRatingGroup())
+                                    .setValidityTime(86400)
                                     .build())
                             .setRequestId(event.getOcsgwRequestId())
                             .build();

--- a/prime/src/main/java/com/telenordigital/prime/ocs/EventHandlerImpl.java
+++ b/prime/src/main/java/com/telenordigital/prime/ocs/EventHandlerImpl.java
@@ -71,10 +71,14 @@ final class EventHandlerImpl implements EventHandler<PrimeEvent> {
         try {
             final CreditControlAnswerInfo creditControlAnswer =
                     CreditControlAnswerInfo.newBuilder().
-                    setMsisdn(event.getMsisdn()).
-                    setMscc(0, MultipleServiceCreditControl.newBuilder().setGranted(GrantedServiceUnit.newBuilder().setTotalOctets(event.getReservedBucketBytes()).build()).build()).
-                    setRequestId(event.getOcsgwRequestId()).
-                    build();
+                            setMsisdn(event.getMsisdn()).
+                            addMscc(MultipleServiceCreditControl.newBuilder().setGranted(
+                                    GrantedServiceUnit.newBuilder().setTotalOctets(event.getReservedBucketBytes()).build())
+                                    .setServiceIdentifier(event.getServiceIdentifier())
+                                    .setRatingGroup(event.getRatingGroup())
+                                    .build())
+                            .setRequestId(event.getOcsgwRequestId())
+                            .build();
             ocsService.sendCreditControlAnswer(event.getOcsgwStreamId(), creditControlAnswer);
         } catch (Exception e) {
             LOG.warn("Exception handling prime event", e);

--- a/prime/src/main/java/com/telenordigital/prime/ocs/OcsService.java
+++ b/prime/src/main/java/com/telenordigital/prime/ocs/OcsService.java
@@ -98,11 +98,11 @@ public final class OcsService  {
     }
 
     public void sendCreditControlAnswer(String streamId, CreditControlAnswerInfo creditControlAnswerInfo) {
-        final StreamObserver<CreditControlAnswerInfo> fetchDataBucketResponse
+        final StreamObserver<CreditControlAnswerInfo> creditControlAnswer
                 = getCreditControlClientForStream(streamId);
 
-        if (fetchDataBucketResponse != null) {
-            fetchDataBucketResponse.onNext(creditControlAnswerInfo);
+        if (creditControlAnswer != null) {
+            creditControlAnswer.onNext(creditControlAnswerInfo);
         }
     }
 }

--- a/prime/src/main/java/com/telenordigital/prime/ocs/OcsState.java
+++ b/prime/src/main/java/com/telenordigital/prime/ocs/OcsState.java
@@ -113,12 +113,12 @@ public final class OcsState implements EventHandler<PrimeEvent> {
         checkNotNull(msisdn);
         Preconditions.checkArgument(usedBytes > -1, "Non-positive value for bytes");
 
-        final long existing = dataPackMap.get(msisdn);
-
         if (!dataPackMap.containsKey(msisdn)) {
             LOG.warn("Used-Units for unknown msisdn : " + msisdn);
             return 0;
         }
+
+        final long existing = dataPackMap.get(msisdn);
 
         if (usedBytes == 0) {
             return existing;

--- a/prime/src/test/java/com/telenordigital/prime/disruptor/PrimeEventProducerTest.java
+++ b/prime/src/test/java/com/telenordigital/prime/disruptor/PrimeEventProducerTest.java
@@ -103,10 +103,12 @@ public class PrimeEventProducerTest {
                         newBuilder().
                         setMsisdn(MSISDN).
                         addMscc(MultipleServiceCreditControl.newBuilder()
-                                .setRequested(
-                                        ReguestedServiceUnit.newBuilder().setTotalOctets(NO_OF_TOPUP_BYTES
-                                        ).build())
+                                .setRequested(ReguestedServiceUnit.newBuilder()
+                                        .setTotalOctets(NO_OF_TOPUP_BYTES)
+                                        .build())
                                 .setUsed(UsedServiceUnit.newBuilder().setTotalOctets(0L).build())
+                                .setRatingGroup(10)
+                                .setServiceIdentifier(1)
                                 .build()
                         ).build();
 
@@ -116,6 +118,8 @@ public class PrimeEventProducerTest {
         assertEquals(MSISDN, event.getMsisdn());
         assertEquals(NO_OF_TOPUP_BYTES, event.getRequestedBucketBytes());
         assertEquals(0L, event.getUsedBucketBytes());
+        assertEquals(10, event.getRatingGroup());
+        assertEquals(1, event.getServiceIdentifier());
         assertEquals(STREAM_ID, event.getOcsgwStreamId());
         assertEquals(CREDIT_CONTROL_REQUEST, event.getMessageType());
     }

--- a/prime/src/test/java/com/telenordigital/prime/disruptor/PrimeEventProducerTest.java
+++ b/prime/src/test/java/com/telenordigital/prime/disruptor/PrimeEventProducerTest.java
@@ -28,6 +28,10 @@ public class PrimeEventProducerTest {
 
     private static final long NO_OF_TOPUP_BYTES = 991234L;
 
+    private static final long REQUESTED_BYTES = 500L;
+
+    private static final long USED_BYTES = 300L;
+
     private static final String MSISDN = "+4711223344";
 
     private static final String STREAM_ID = "mySecret stream";
@@ -48,7 +52,7 @@ public class PrimeEventProducerTest {
     @SuppressWarnings("unchecked")
     @Before
     public void setUp() {
-        this.disruptor = new Disruptor<PrimeEvent>(
+        this.disruptor = new Disruptor<>(
             ()-> new PrimeEvent(),
             RING_BUFFER_SIZE,
             Executors.defaultThreadFactory() );
@@ -68,7 +72,7 @@ public class PrimeEventProducerTest {
     }
 
     private PrimeEvent getCollectedEvent()  throws InterruptedException {
-        // Wait  wait a short while for the thing to process.
+        // Wait a short while for the thing to process.
         assertTrue(cdl.await(TIMEOUT, TimeUnit.SECONDS));
         assertFalse(result.isEmpty());
         final PrimeEvent event = result.iterator().next();
@@ -104,9 +108,9 @@ public class PrimeEventProducerTest {
                         setMsisdn(MSISDN).
                         addMscc(MultipleServiceCreditControl.newBuilder()
                                 .setRequested(ReguestedServiceUnit.newBuilder()
-                                        .setTotalOctets(NO_OF_TOPUP_BYTES)
+                                        .setTotalOctets(REQUESTED_BYTES)
                                         .build())
-                                .setUsed(UsedServiceUnit.newBuilder().setTotalOctets(0L).build())
+                                .setUsed(UsedServiceUnit.newBuilder().setTotalOctets(USED_BYTES).build())
                                 .setRatingGroup(10)
                                 .setServiceIdentifier(1)
                                 .build()
@@ -116,8 +120,8 @@ public class PrimeEventProducerTest {
 
         final PrimeEvent event = getCollectedEvent();
         assertEquals(MSISDN, event.getMsisdn());
-        assertEquals(NO_OF_TOPUP_BYTES, event.getRequestedBucketBytes());
-        assertEquals(0L, event.getUsedBucketBytes());
+        assertEquals(REQUESTED_BYTES, event.getRequestedBucketBytes());
+        assertEquals(USED_BYTES, event.getUsedBucketBytes());
         assertEquals(10, event.getRatingGroup());
         assertEquals(1, event.getServiceIdentifier());
         assertEquals(STREAM_ID, event.getOcsgwStreamId());

--- a/prime/src/test/java/com/telenordigital/prime/disruptor/PrimeEventProducerTest.java
+++ b/prime/src/test/java/com/telenordigital/prime/disruptor/PrimeEventProducerTest.java
@@ -97,7 +97,7 @@ public class PrimeEventProducerTest {
     }
 
     @Test
-    public void CreditControlRequestEvent() throws Exception {
+    public void creditControlRequestEvent() throws Exception {
         final CreditControlRequestInfo request =
                 CreditControlRequestInfo.
                         newBuilder().

--- a/prime/src/test/java/com/telenordigital/prime/events/EventProcessorTest.java
+++ b/prime/src/test/java/com/telenordigital/prime/events/EventProcessorTest.java
@@ -14,7 +14,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import static com.telenordigital.prime.disruptor.PrimeEventMessageType.GET_DATA_BUNDLE_BALANCE;
-import static com.telenordigital.prime.disruptor.PrimeEventMessageType.RETURN_UNUSED_DATA_BUCKET;
+import static com.telenordigital.prime.disruptor.PrimeEventMessageType.RELEASE_RESERVED_BUCKET;
 import static com.telenordigital.prime.storage.Products.DATA_TOPUP_3GB;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -116,10 +116,10 @@ public final class EventProcessorTest {
     }
 
     @Test
-    public void testPrimeEventReturnUnusedDataBucket() throws Exception {
+    public void testPrimeEventReleaseReservedDataBucket() throws Exception {
         final long noOfBytes = 4711L;
         final PrimeEvent primeEvent = new PrimeEvent();
-        primeEvent.setMessageType(RETURN_UNUSED_DATA_BUCKET);
+        primeEvent.setMessageType(RELEASE_RESERVED_BUCKET);
         primeEvent.setMsisdn(MSISDN);
         primeEvent.setBundleBytes(noOfBytes);
 

--- a/prime/src/test/java/com/telenordigital/prime/ocs/OcsServiceTest.java
+++ b/prime/src/test/java/com/telenordigital/prime/ocs/OcsServiceTest.java
@@ -34,7 +34,7 @@ public class OcsServiceTest {
 
     @Before
     public void setUp() {
-        this.disruptor = new Disruptor<PrimeEvent>(
+        this.disruptor = new Disruptor<>(
             ()-> new PrimeEvent(),
             RING_BUFFER_SIZE,
             Executors.defaultThreadFactory() );

--- a/prime/src/test/java/com/telenordigital/prime/ocs/OcsStateTest.java
+++ b/prime/src/test/java/com/telenordigital/prime/ocs/OcsStateTest.java
@@ -32,8 +32,8 @@ public class OcsStateTest {
 
         final OcsState ocsState = new OcsState();
 
-        // Add a thousand, starting from zero. This means that the addDatBytes will
-        // return the  new balande (after addition), which is 1000.
+        // Add a thousand, starting from zero. This means that the addDataBytes will
+        // return the  new balance (after addition), which is 1000.
         assertEquals(INITIAL_NUMBER_OF_BYTES_TO_ADD,
                 ocsState.addDataBundleBytes(MSISDN, INITIAL_NUMBER_OF_BYTES_TO_ADD));
 
@@ -73,6 +73,29 @@ public class OcsStateTest {
 
         //... so at this point even reserving a single byte will fail.
         assertEquals(0, ocsState.reserveDataBytes(MSISDN, 1));
+    }
+
+    @Test
+    public void testReleaseDataBytes() {
+
+        final OcsState ocsState = new OcsState();
+
+        // First store a thousand
+        assertEquals(INITIAL_NUMBER_OF_BYTES_TO_ADD,
+                ocsState.addDataBundleBytes(MSISDN, INITIAL_NUMBER_OF_BYTES_TO_ADD));
+
+        // Then reserve, and get 700
+        assertEquals(INITIAL_NUMBER_OF_BYTES_TO_REQUEST,
+                ocsState.reserveDataBytes(MSISDN, INITIAL_NUMBER_OF_BYTES_TO_REQUEST));
+
+        // Checking that the balance is 300.
+        assertEquals(REMAINING_BYTES, ocsState.getDataBundleBytes(MSISDN));
+
+        // Then release the reserved bucket, and get 700 as the released size
+        assertEquals(INITIAL_NUMBER_OF_BYTES_TO_REQUEST, ocsState.releaseReservedBucket(MSISDN));
+
+        // Checking that the balance is back to 1000.
+        assertEquals(INITIAL_NUMBER_OF_BYTES_TO_ADD, ocsState.getDataBundleBytes(MSISDN));
     }
 
 

--- a/prime/src/test/java/com/telenordigital/prime/ocs/OcsStateTest.java
+++ b/prime/src/test/java/com/telenordigital/prime/ocs/OcsStateTest.java
@@ -22,6 +22,8 @@ public class OcsStateTest {
 
     private static final int INITIAL_NUMBER_OF_BYTES_TO_REQUEST = 700;
 
+    private static final int REMAINING_BYTES = 300;
+
     private static final int SECOND_NUMBER_OF_BYTES_TO_REQUEST = 400;
 
 
@@ -33,18 +35,18 @@ public class OcsStateTest {
         // Add a thousand, starting from zero. This means that the addDatBytes will
         // return the  new balande (after addition), which is 1000.
         assertEquals(INITIAL_NUMBER_OF_BYTES_TO_ADD,
-                ocsState.addDataBytes(MSISDN, INITIAL_NUMBER_OF_BYTES_TO_ADD));
+                ocsState.addDataBundleBytes(MSISDN, INITIAL_NUMBER_OF_BYTES_TO_ADD));
 
         // Just checking that the balance is still 1000.
-        assertEquals(INITIAL_NUMBER_OF_BYTES_TO_ADD, ocsState.getDataBytes(MSISDN));
+        assertEquals(INITIAL_NUMBER_OF_BYTES_TO_ADD, ocsState.getDataBundleBytes(MSISDN));
 
         // Adding 500, should increase balance up to 1500  ;-)
         assertEquals(FINAL_NUMBER_OF_BYTES,
-                ocsState.addDataBytes(MSISDN, TOPUP_NUMBER_OF_BYTES_TO_ADD));
+                ocsState.addDataBundleBytes(MSISDN, TOPUP_NUMBER_OF_BYTES_TO_ADD));
 
         // And we should still have FINAL_NUMBER_OF_BYTES (1500).
         assertEquals(FINAL_NUMBER_OF_BYTES,
-                ocsState.getDataBytes(MSISDN));
+                ocsState.getDataBundleBytes(MSISDN));
     }
 
     @Test
@@ -54,20 +56,23 @@ public class OcsStateTest {
 
         // First store a thousand
         assertEquals(INITIAL_NUMBER_OF_BYTES_TO_ADD,
-                ocsState.addDataBytes(MSISDN, INITIAL_NUMBER_OF_BYTES_TO_ADD));
+                ocsState.addDataBundleBytes(MSISDN, INITIAL_NUMBER_OF_BYTES_TO_ADD));
 
-        // Then request, and get 700
+        // Then reserve, and get 700
         assertEquals(INITIAL_NUMBER_OF_BYTES_TO_REQUEST,
+                ocsState.reserveDataBytes(MSISDN, INITIAL_NUMBER_OF_BYTES_TO_REQUEST));
+
+        // Then consume 700 from the reserved
+        assertEquals(REMAINING_BYTES,
                 ocsState.consumeDataBytes(MSISDN, INITIAL_NUMBER_OF_BYTES_TO_REQUEST));
 
         // Now request 400, but that's too much, so only 300 is returned, and
         // after this transaction the balance is zero.
-        final int expectedPermittedReturn = 300;
-        assertEquals(expectedPermittedReturn,
-                ocsState.consumeDataBytes(MSISDN, SECOND_NUMBER_OF_BYTES_TO_REQUEST));
+        assertEquals(REMAINING_BYTES,
+                ocsState.reserveDataBytes(MSISDN, SECOND_NUMBER_OF_BYTES_TO_REQUEST));
 
-        //... so at this point even requesting a single byte will fail.
-        assertEquals(0, ocsState.consumeDataBytes(MSISDN, 1));
+        //... so at this point even reserving a single byte will fail.
+        assertEquals(0, ocsState.reserveDataBytes(MSISDN, 1));
     }
 
 

--- a/prime/src/test/java/com/telenordigital/prime/ocs/OcsStateTest.java
+++ b/prime/src/test/java/com/telenordigital/prime/ocs/OcsStateTest.java
@@ -21,8 +21,10 @@ public class OcsStateTest {
             INITIAL_NUMBER_OF_BYTES_TO_ADD + TOPUP_NUMBER_OF_BYTES_TO_ADD;
 
     private static final int INITIAL_NUMBER_OF_BYTES_TO_REQUEST = 700;
+    private static final int OVER_CONSUME_BUCKET = 750;
 
     private static final int REMAINING_BYTES = 300;
+    private static final int OVER_CONSUME_REMAINING_BYTES = 250;
 
     private static final int SECOND_NUMBER_OF_BYTES_TO_REQUEST = 400;
 
@@ -74,6 +76,35 @@ public class OcsStateTest {
         //... so at this point even reserving a single byte will fail.
         assertEquals(0, ocsState.reserveDataBytes(MSISDN, 1));
     }
+
+
+    @Test
+    public void testOverConsumtionDataBytes() {
+
+        final OcsState ocsState = new OcsState();
+
+        // First store a thousand
+        assertEquals(INITIAL_NUMBER_OF_BYTES_TO_ADD,
+                ocsState.addDataBundleBytes(MSISDN, INITIAL_NUMBER_OF_BYTES_TO_ADD));
+
+        // Then reserve, and get 700
+        assertEquals(INITIAL_NUMBER_OF_BYTES_TO_REQUEST,
+                ocsState.reserveDataBytes(MSISDN, INITIAL_NUMBER_OF_BYTES_TO_REQUEST));
+
+        // Then consume 750 from the reserved
+        assertEquals(OVER_CONSUME_REMAINING_BYTES,
+                ocsState.consumeDataBytes(MSISDN, OVER_CONSUME_BUCKET));
+
+        // Now request 400, but that's too much, so only 250 is returned, and
+        // after this transaction the balance is zero.
+        assertEquals(OVER_CONSUME_REMAINING_BYTES,
+                ocsState.reserveDataBytes(MSISDN, SECOND_NUMBER_OF_BYTES_TO_REQUEST));
+
+        //... so at this point even reserving a single byte will fail.
+        assertEquals(0, ocsState.reserveDataBytes(MSISDN, 1));
+    }
+
+
 
     @Test
     public void testReleaseDataBytes() {


### PR DESCRIPTION
This will add more information from the Credit control requests.

The ocs-api has been updated with the following changes.

* Requests has been renamed to CreditControlRequest and the reply to CreditControlAnswer to match the DIAMETER part.

* CreditControlRequest now include both the MSISDN and IMSI

*  CreditControlRequest include Service-Information like SGSN-MNC-MCC and APN (Called-Station-Id)

* Both CreditControlRequest and CreditControlAnswer support Multi-Service-Credit-Control with requested, used and granted bytes. There is also support for Service-Id and Rating-Group.

* CreditControlAnswer now suport Final-Unit-Indication.

* First cut at support for Final-Unit-Action restrict and redirect.


Currently there is only support for one Multi-Service-Credit-Control. So the first one in the list will be used to make reservations and update usage.