### PR TITLE
Do not use DIAMETER_CREDIT_LIMIT_REACHED with graceful shutdown

### DIFF
--- a/diameter-stack/src/main/kotlin/org/ostelco/diameter/CreditControlContext.kt
+++ b/diameter-stack/src/main/kotlin/org/ostelco/diameter/CreditControlContext.kt
@@ -61,12 +61,10 @@ class CreditControlContext(
                 if (originalCreditControlRequest.requestTypeAVPValue != RequestType.TERMINATION_REQUEST) {
 
                     if (mscc.finalUnitIndication != null) {
-                        val gsuAvp = answerMSCC.addGroupedAvp(Avp.GRANTED_SERVICE_UNIT, true, false)
-                        gsuAvp.addAvp(Avp.CC_TOTAL_OCTETS, 0L, true, false)
                         addFinalUnitAction(answerMSCC, mscc)
                     }
 
-                    if (mscc.granted.total > 1) {
+                    if (mscc.granted.total > -1) {
                         val gsuAvp = answerMSCC.addGroupedAvp(Avp.GRANTED_SERVICE_UNIT, true, false)
                         gsuAvp.addAvp(Avp.CC_INPUT_OCTETS, 0L, true, false)
                         gsuAvp.addAvp(Avp.CC_OUTPUT_OCTETS, 0L, true, false)

--- a/diameter-stack/src/main/kotlin/org/ostelco/diameter/CreditControlContext.kt
+++ b/diameter-stack/src/main/kotlin/org/ostelco/diameter/CreditControlContext.kt
@@ -58,25 +58,20 @@ class CreditControlContext(
                     answerMSCC.addAvp(Avp.SERVICE_IDENTIFIER_CCA, mscc.serviceIdentifier.toInt(), true, false)
                 }
 
-                if (mscc.finalUnitIndication != null) {
-                    if (originalCreditControlRequest.requestTypeAVPValue != RequestType.TERMINATION_REQUEST) {
-                        resultCode = CreditControlResultCode.DIAMETER_CREDIT_LIMIT_REACHED.value
+                if (originalCreditControlRequest.requestTypeAVPValue != RequestType.TERMINATION_REQUEST) {
+
+                    if (mscc.finalUnitIndication != null) {
+                        val gsuAvp = answerMSCC.addGroupedAvp(Avp.GRANTED_SERVICE_UNIT, true, false)
+                        gsuAvp.addAvp(Avp.CC_TOTAL_OCTETS, 0L, true, false)
+                        addFinalUnitAction(answerMSCC, mscc)
                     }
 
-                    // Since this is a terminate reply no service is granted
-                    val gsuAvp = answerMSCC.addGroupedAvp(Avp.GRANTED_SERVICE_UNIT, true, false)
-                    gsuAvp.addAvp(Avp.CC_INPUT_OCTETS, 0L, true, false)
-                    gsuAvp.addAvp(Avp.CC_OUTPUT_OCTETS, 0L, true, false)
-                    gsuAvp.addAvp(Avp.CC_TIME, 0, true, false)
-                    gsuAvp.addAvp(Avp.CC_TOTAL_OCTETS, 0L, true, false)
-                    gsuAvp.addAvp(Avp.CC_SERVICE_SPECIFIC_UNITS, 0L, true, false)
-
-                    addFinalUnitAction(answerMSCC, mscc)
-                } else if (mscc.granted.total > 1 ) {
-                    val gsuAvp = answerMSCC.addGroupedAvp(Avp.GRANTED_SERVICE_UNIT, true, false)
-                    gsuAvp.addAvp(Avp.CC_INPUT_OCTETS, 0L, true, false)
-                    gsuAvp.addAvp(Avp.CC_OUTPUT_OCTETS, 0L, true, false)
-                    gsuAvp.addAvp(Avp.CC_TOTAL_OCTETS, mscc.granted.total, true, false)
+                    if (mscc.granted.total > 1) {
+                        val gsuAvp = answerMSCC.addGroupedAvp(Avp.GRANTED_SERVICE_UNIT, true, false)
+                        gsuAvp.addAvp(Avp.CC_INPUT_OCTETS, 0L, true, false)
+                        gsuAvp.addAvp(Avp.CC_OUTPUT_OCTETS, 0L, true, false)
+                        gsuAvp.addAvp(Avp.CC_TOTAL_OCTETS, mscc.granted.total, true, false)
+                    }
                 }
                 answerMSCC.addAvp(Avp.RESULT_CODE, resultCode, true, false)
                 answerMSCC.addAvp(Avp.VALIDITY_TIME, mscc.validityTime, true, false)

--- a/ext-pgw/src/main/java/org/ostelco/ext_pgw/OcsIntegrationTest.java
+++ b/ext-pgw/src/main/java/org/ostelco/ext_pgw/OcsIntegrationTest.java
@@ -165,7 +165,7 @@ public class OcsIntegrationTest {
             assertEquals(DEST_REALM, resultAvps.getAvp(Avp.ORIGIN_REALM).getUTF8String());
             assertEquals(RequestType.INITIAL_REQUEST, resultAvps.getAvp(Avp.CC_REQUEST_TYPE).getInteger32());
             Avp resultMSCC = resultAvps.getAvp(Avp.MULTIPLE_SERVICES_CREDIT_CONTROL);
-            assertEquals(4012L, resultMSCC.getGrouped().getAvp(Avp.RESULT_CODE).getInteger32());
+            assertEquals(2001L, resultMSCC.getGrouped().getAvp(Avp.RESULT_CODE).getInteger32());
             assertEquals(1, resultMSCC.getGrouped().getAvp(Avp.SERVICE_IDENTIFIER_CCA).getInteger32());
             Avp granted = resultMSCC.getGrouped().getAvp(Avp.GRANTED_SERVICE_UNIT);
             assertEquals(0L, granted.getGrouped().getAvp(Avp.CC_TOTAL_OCTETS).getUnsigned64());

--- a/ocsgw/src/test/java/org/ostelco/ocsgw/OcsApplicationTest.java
+++ b/ocsgw/src/test/java/org/ostelco/ocsgw/OcsApplicationTest.java
@@ -146,10 +146,6 @@ public class OcsApplicationTest {
             assertEquals(RequestType.TERMINATION_REQUEST, resultAvps.getAvp(Avp.CC_REQUEST_TYPE).getInteger32());
             Avp resultMSCC = resultAvps.getAvp(Avp.MULTIPLE_SERVICES_CREDIT_CONTROL);
             assertEquals(2001L, resultMSCC.getGrouped().getAvp(Avp.RESULT_CODE).getInteger32());
-            Avp granted = resultMSCC.getGrouped().getAvp(Avp.GRANTED_SERVICE_UNIT);
-            assertEquals(0L, granted.getGrouped().getAvp(Avp.CC_TOTAL_OCTETS).getUnsigned64());
-            AvpSet finalUnitIndication = resultMSCC.getGrouped().getAvp(Avp.FINAL_UNIT_INDICATION).getGrouped();
-            assertEquals(FinalUnitAction.TERMINATE.ordinal(), finalUnitIndication.getAvp(Avp.FINAL_UNIT_ACTION).getInteger32());
         } catch (AvpDataException e) {
             LOG.error("Failed to get Result-Code", e);
         }

--- a/prime/src/main/kotlin/org/ostelco/prime/ocs/EventHandlerImpl.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/ocs/EventHandlerImpl.kt
@@ -85,6 +85,11 @@ internal class EventHandlerImpl(private val ocsService: OcsService) : EventHandl
                                 .setIsSet(true)
                                 .build())
                     }
+                } else {
+                    // Use -1 to indicate no granted service unit should be included in the answer
+                    msccBulder.setGranted(ServiceUnit.newBuilder()
+                            .setTotalOctets(-1)
+                            .build())
                 }
                 creditControlAnswer.addMscc(msccBulder.build())
             }

--- a/prime/src/main/kotlin/org/ostelco/prime/ocs/EventHandlerImpl.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/ocs/EventHandlerImpl.kt
@@ -79,7 +79,7 @@ internal class EventHandlerImpl(private val ocsService: OcsService) : EventHandl
                     msccBulder.setGranted(ServiceUnit.newBuilder()
                             .setTotalOctets(event.reservedBucketBytes)
                             .build())
-                    if (event.reservedBucketBytes == 0L) {
+                    if (event.reservedBucketBytes < event.requestedBucketBytes) {
                         msccBulder.setFinalUnitIndication(FinalUnitIndication.newBuilder()
                                 .setFinalUnitAction(FinalUnitAction.TERMINATE)
                                 .setIsSet(true)


### PR DESCRIPTION
When we use Final-Unit-Indication it should not be combined with
DIAMETER_CREDIT_LIMIT_REACHED.