### PR TITLE
Firebase Refactor

### DIFF
--- a/prime/src/main/kotlin/org/ostelco/prime/firebase/FbDatabaseFacade.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/firebase/FbDatabaseFacade.kt
@@ -322,7 +322,7 @@ class FbDatabaseFacade internal constructor(firebaseDatabase: FirebaseDatabase) 
         val cdl = CountDownLatch(1)
         val result = HashSet<Subscriber>()
 
-        val q = authorativeUserBalance.child(MSISDN)
+        val q = authorativeUserBalance.child(msisdn)
 
         val listenerThatWillReadSubcriberData = newListenerThatWillReadSubcriberData(cdl, result)
 
@@ -437,7 +437,6 @@ class FbDatabaseFacade internal constructor(firebaseDatabase: FirebaseDatabase) 
                     } catch (e: Exception) {
                         LOG.error("Couldn't dispatch purchase request to consumer", e)
                     }
-
                 }
             }
         }

--- a/prime/src/main/kotlin/org/ostelco/prime/firebase/FbDatabaseFacade.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/firebase/FbDatabaseFacade.kt
@@ -448,7 +448,7 @@ class FbDatabaseFacade internal constructor(firebaseDatabase: FirebaseDatabase) 
             }
         }
 
-        fun stripLeadingPlus(str: String): String {
+        private fun stripLeadingPlus(str: String): String {
             return str.replaceFirst("^\\+".toRegex(), "")
         }
     }

--- a/prime/src/main/kotlin/org/ostelco/prime/firebase/FbStorage.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/firebase/FbStorage.kt
@@ -132,14 +132,14 @@ constructor(databaseName: String,
     }
 
     override fun addRecordOfPurchaseByMsisdn(
-            msisdn: String,
+            ephermeralMsisdn: String,
             sku: String,
-            millisSinceEpoch: Long): String {
-        checkNotNull(msisdn)
+            now: Long): String {
+        checkNotNull(ephermeralMsisdn)
         checkNotNull(sku)
-        checkArgument(millisSinceEpoch > 0)
+        checkArgument(now > 0)
 
-        return facade.addRecordOfPurchaseByMsisdn(msisdn, sku, millisSinceEpoch)
+        return facade.addRecordOfPurchaseByMsisdn(ephermeralMsisdn, sku, now)
     }
 
     @Throws(StorageException::class)
@@ -172,15 +172,14 @@ constructor(databaseName: String,
             throw StorageException("noOfBytes can't be negative")
         }
 
-        val sub = getSubscriberFromMsisdn(msisdn) as SubscriberImpl?
-                ?: throw StorageException("Unknown msisdn " + msisdn)
-
+        val sub = SubscriberImpl()
+        sub.setMsisdn(msisdn)
         sub.setNoOfBytesLeft(noOfBytes)
 
         facade.updateAuthorativeUserData(sub)
     }
 
-    override fun insertNewSubscriber(msisdn: String): String {
+    override fun insertNewSubscriber(msisdn: String) {
         checkNotNull(msisdn)
         val sub = SubscriberImpl()
         sub.setMsisdn(msisdn)

--- a/prime/src/main/kotlin/org/ostelco/prime/firebase/FbStorage.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/firebase/FbStorage.kt
@@ -172,8 +172,7 @@ constructor(databaseName: String,
             throw StorageException("noOfBytes can't be negative")
         }
 
-        val sub = SubscriberImpl()
-        sub.setMsisdn(msisdn)
+        val sub = SubscriberImpl(msisdn)
         sub.setNoOfBytesLeft(noOfBytes)
 
         facade.updateAuthorativeUserData(sub)
@@ -181,8 +180,7 @@ constructor(databaseName: String,
 
     override fun insertNewSubscriber(msisdn: String) {
         checkNotNull(msisdn)
-        val sub = SubscriberImpl()
-        sub.setMsisdn(msisdn)
+        val sub = SubscriberImpl(msisdn)
         return facade.insertNewSubscriber(sub)
     }
 }

--- a/prime/src/main/kotlin/org/ostelco/prime/storage/Storage.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/storage/Storage.kt
@@ -31,7 +31,7 @@ interface Storage : ProductDescriptionCache {
     fun getSubscriberFromMsisdn(msisdn: String): Subscriber?
 
     @Throws(StorageException::class)
-    fun insertNewSubscriber(msisdn: String): String
+    fun insertNewSubscriber(msisdn: String)
 
     @Throws(StorageException::class)
     fun removeSubscriberByMsisdn(msisdn: String)

--- a/prime/src/main/kotlin/org/ostelco/prime/storage/entities/SubscriberImpl.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/storage/entities/SubscriberImpl.kt
@@ -2,8 +2,6 @@ package org.ostelco.prime.storage.entities
 
 
 class SubscriberImpl : Subscriber {
-
-    var fbKey: String? = null
     private var _msisdn: String? = null
     private var _noOfBytesLeft: Long = 0
 

--- a/prime/src/main/kotlin/org/ostelco/prime/storage/entities/SubscriberImpl.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/storage/entities/SubscriberImpl.kt
@@ -1,6 +1,9 @@
 package org.ostelco.prime.storage.entities
 
-
+/**
+ * The subscriber information that is stored
+ * in the DB.
+ */
 class SubscriberImpl() : Subscriber {
 
     constructor(msisdn: String) : this() {

--- a/prime/src/main/kotlin/org/ostelco/prime/storage/entities/SubscriberImpl.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/storage/entities/SubscriberImpl.kt
@@ -1,7 +1,12 @@
 package org.ostelco.prime.storage.entities
 
 
-class SubscriberImpl : Subscriber {
+class SubscriberImpl() : Subscriber {
+
+    constructor(msisdn: String) : this() {
+        _msisdn = msisdn
+    }
+
     private var _msisdn: String? = null
     private var _noOfBytesLeft: Long = 0
 

--- a/prime/src/test/kotlin/org/ostelco/prime/storage/entities/SubscriberImplTest.kt
+++ b/prime/src/test/kotlin/org/ostelco/prime/storage/entities/SubscriberImplTest.kt
@@ -6,12 +6,14 @@ import org.junit.Test
 
 class SubscriberImplTest {
 
+    val MSISDN = "+47123456"
+
     companion object {
         private const val NO_OF_BYTES_LEFT_KEY = "noOfBytesLeft"
         private const val MSISDN_KEY = "msisdn"
     }
 
-    private val fbs = SubscriberImpl()
+    private val fbs = SubscriberImpl(MSISDN)
 
     @Test
     fun asMap() {
@@ -20,7 +22,7 @@ class SubscriberImplTest {
         assertTrue(fbs.asMap().containsKey(MSISDN_KEY))
 
         assertEquals(0L, fbs.asMap()[NO_OF_BYTES_LEFT_KEY])
-        assertEquals(null, fbs.asMap()[MSISDN_KEY])
+        assertEquals(MSISDN, fbs.asMap()[MSISDN_KEY])
     }
 
     @Test
@@ -33,8 +35,8 @@ class SubscriberImplTest {
 
     @Test
     fun getAndSetMsisdn() {
-        assertEquals(null, fbs.msisdn)
-        val msisdn = "+47123456"
+        assertEquals(MSISDN, fbs.msisdn)
+        val msisdn = "+4712345678"
         fbs.setMsisdn(msisdn)
         assertEquals(msisdn, fbs.msisdn)
     }

--- a/prime/src/test/kotlin/org/ostelco/prime/storage/entities/SubscriberImplTest.kt
+++ b/prime/src/test/kotlin/org/ostelco/prime/storage/entities/SubscriberImplTest.kt
@@ -24,14 +24,6 @@ class SubscriberImplTest {
     }
 
     @Test
-    fun getAndSetFbKey() {
-        assertEquals(null, fbs.fbKey)
-        val fbkey = "foobar"
-        fbs.fbKey = fbkey
-        assertEquals(fbkey, fbs.fbKey)
-    }
-
-    @Test
     fun getAndSetNoOfBytesLeft() {
         assertEquals(0L, fbs.noOfBytesLeft)
         val noOfBytesLeft = 123823838L


### PR DESCRIPTION
Fix all deprication warnings

Changed tree structure for authorative-user-storage. The child
key is now the msisdn instead of random ids. This will make
updates quicker as the code to find a single subscriber can be
removed and one can update child balance directly.
No longer any need for the sync firebase calls in the updates