### PR TITLE
Store purchase request under msisdn key

### DIFF
--- a/ocs/src/main/kotlin/org/ostelco/prime/ocs/OcsServer.kt
+++ b/ocs/src/main/kotlin/org/ostelco/prime/ocs/OcsServer.kt
@@ -40,7 +40,7 @@ class OcsServer(private val port: Int, service: BindableService) : Managed {
     @Throws(InterruptedException::class)
     override fun stop() {
         if (server != null) {
-            LOG.info("Stopping OcsServer Server  listening for gRPC traffic on  {}", port)
+            LOG.info("Stopping OcsServer Server listening for gRPC traffic on  {}", port)
             server.shutdown()
             blockUntilShutdown()
         }

--- a/ocs/src/main/kotlin/org/ostelco/prime/ocs/OcsState.kt
+++ b/ocs/src/main/kotlin/org/ostelco/prime/ocs/OcsState.kt
@@ -14,8 +14,6 @@ class OcsState : EventHandler<PrimeEvent> {
     private val dataPackMap = HashMap<String, Long>()
     private val bucketReservedMap = HashMap<String, Long>()
 
-    var lowBalanceThreshold = 0L;
-
     override fun onEvent(
             event: PrimeEvent,
             sequence: Long,
@@ -33,7 +31,6 @@ class OcsState : EventHandler<PrimeEvent> {
                             msisdn,
                             event.requestedBucketBytes)
                     event.bundleBytes = getDataBundleBytes(msisdn)
-                    checkThresholds(event)
                 }
                 PrimeEventMessageType.TOPUP_DATA_BUNDLE_BALANCE -> event.bundleBytes = addDataBundleBytes(msisdn, event.requestedBucketBytes)
                 PrimeEventMessageType.GET_DATA_BUNDLE_BALANCE -> event.bundleBytes = getDataBundleBytes(msisdn)
@@ -41,15 +38,6 @@ class OcsState : EventHandler<PrimeEvent> {
             }
         } catch (e: Exception) {
             LOG.warn("Exception handling prime event in OcsState", e)
-        }
-    }
-
-    private fun checkThresholds(event: PrimeEvent) {
-        if (event.bundleBytes < lowBalanceThreshold) {
-            // Did we just cross the threshold
-            if (event.bundleBytes + event.reservedBucketBytes > lowBalanceThreshold) {
-                //sendPushNotification()
-            }
         }
     }
 

--- a/prime/src/integration-tests/kotlin/org/ostelco/prime/firebase/FbStorageTest.kt
+++ b/prime/src/integration-tests/kotlin/org/ostelco/prime/firebase/FbStorageTest.kt
@@ -95,7 +95,7 @@ class FbStorageTest {
                 sku = DATA_TOPUP_3GB.sku,
                 millisSinceEpoch = now)
         val id = storage.addRecordOfPurchase(purchase)
-        storage.removeRecordOfPurchaseById(id)
+        storage.removeRecordOfPurchaseById(purchase, id)
     }
 
     @Test

--- a/prime/src/integration-tests/kotlin/org/ostelco/prime/firebase/FbStorageTest.kt
+++ b/prime/src/integration-tests/kotlin/org/ostelco/prime/firebase/FbStorageTest.kt
@@ -95,7 +95,7 @@ class FbStorageTest {
                 sku = DATA_TOPUP_3GB.sku,
                 millisSinceEpoch = now)
         val id = storage.addRecordOfPurchase(purchase)
-        storage.removeRecordOfPurchaseById(purchase, id)
+        storage.removeRecordOfPurchaseById(purchase.msisdn, id)
     }
 
     @Test

--- a/prime/src/main/kotlin/org/ostelco/prime/PrimeApplication.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/PrimeApplication.kt
@@ -36,9 +36,13 @@ class PrimeApplication : Application<PrimeConfiguration>() {
         // OcsServer assigns OcsService as handler for gRPC requests
         val server = OcsServer(8082, ocsService.asOcsServiceImplBase())
 
+        val ocsConfiguration = primeConfiguration.ocsConfiguration
+
         val ocsState = OcsState()
+        ocsState.lowBalanceThreshold = ocsConfiguration.lowBalanceThreshold;
 
         val eventProcessorConfig = primeConfiguration.eventProcessorConfig
+
 
         val eventHandler = EventHandler()
 

--- a/prime/src/main/kotlin/org/ostelco/prime/PrimeApplication.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/PrimeApplication.kt
@@ -36,10 +36,7 @@ class PrimeApplication : Application<PrimeConfiguration>() {
         // OcsServer assigns OcsService as handler for gRPC requests
         val server = OcsServer(8082, ocsService.asOcsServiceImplBase())
 
-        val ocsConfiguration = primeConfiguration.ocsConfiguration
-
         val ocsState = OcsState()
-        ocsState.lowBalanceThreshold = ocsConfiguration.lowBalanceThreshold;
 
         val eventProcessorConfig = primeConfiguration.eventProcessorConfig
 

--- a/prime/src/main/kotlin/org/ostelco/prime/config/PrimeConfiguration.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/config/PrimeConfiguration.kt
@@ -12,4 +12,9 @@ class PrimeConfiguration : Configuration() {
     @NotNull
     @JsonProperty("eventProcessor")
     lateinit var eventProcessorConfig: EventProcessorConfiguration
+
+    @Valid
+    @NotNull
+    @JsonProperty("ocs")
+    lateinit var ocsConfiguration: OcsConfig
 }

--- a/prime/src/main/kotlin/org/ostelco/prime/config/PrimeConfiguration.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/config/PrimeConfiguration.kt
@@ -12,9 +12,4 @@ class PrimeConfiguration : Configuration() {
     @NotNull
     @JsonProperty("eventProcessor")
     lateinit var eventProcessorConfig: EventProcessorConfiguration
-
-    @Valid
-    @NotNull
-    @JsonProperty("ocs")
-    lateinit var ocsConfiguration: OcsConfig
 }

--- a/prime/src/main/kotlin/org/ostelco/prime/firebase/FbDatabaseFacade.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/firebase/FbDatabaseFacade.kt
@@ -184,7 +184,7 @@ class FbDatabaseFacade internal constructor(firebaseDatabase: FirebaseDatabase) 
         checkNotNull(purchase)
         val asMap = purchase.asMap()
         checkNotNull(asMap)
-        val dbref = recordsOfPurchase.push()
+        val dbref = recordsOfPurchase.child(stripLeadingPlus(purchase.msisdn)).push()
 
         dbref.updateChildrenAsync(asMap)
         return dbref.key
@@ -211,7 +211,8 @@ class FbDatabaseFacade internal constructor(firebaseDatabase: FirebaseDatabase) 
             dbref: DatabaseReference,
             msisdn: String) {
         checkNotNull(msisdn)
-        removeChild(dbref, stripLeadingPlus(msisdn))
+        checkNotNull(dbref)
+        dbref.child(stripLeadingPlus(msisdn)).removeValueAsync()
     }
 
     @Throws(StorageException::class)
@@ -232,22 +233,18 @@ class FbDatabaseFacade internal constructor(firebaseDatabase: FirebaseDatabase) 
         return dbref.key
     }
 
-    fun removeRecordOfPurchaseById(id: String) {
-        removeChild(recordsOfPurchase, id)
+    fun removeRecordOfPurchaseById(purchase: RecordOfPurchase, id: String) {
+        checkNotNull(id)
+        checkNotNull(purchase)
+        checkNotNull(recordsOfPurchase)
+        clientRequests.child(stripLeadingPlus(purchase.msisdn)).child(id).removeValueAsync()
     }
 
 
     fun removePurchaseRequestById(id: String) {
         checkNotNull(id)
-        removeChild(clientRequests, id)
-    }
-
-    private fun removeChild(db: DatabaseReference, childId: String) {
-        // XXX Removes whole tree, not just the subtree for id.
-        //     how do I fix this?
-        checkNotNull(db)
-        checkNotNull(childId)
-        db.child(childId).removeValueAsync()
+        checkNotNull(clientRequests)
+        clientRequests.child(id).removeValueAsync()
     }
 
     @Throws(StorageException::class)

--- a/prime/src/main/kotlin/org/ostelco/prime/firebase/FbDatabaseFacade.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/firebase/FbDatabaseFacade.kt
@@ -233,11 +233,14 @@ class FbDatabaseFacade internal constructor(firebaseDatabase: FirebaseDatabase) 
         return dbref.key
     }
 
-    fun removeRecordOfPurchaseById(purchase: RecordOfPurchase, id: String) {
+    /**
+     * Removes a purchase record by the Firebase ref ID.
+     */
+    fun removeRecordOfPurchaseById(msisdn: String, id: String) {
         checkNotNull(id)
-        checkNotNull(purchase)
+        checkNotNull(msisdn)
         checkNotNull(recordsOfPurchase)
-        clientRequests.child(stripLeadingPlus(purchase.msisdn)).child(id).removeValueAsync()
+        clientRequests.child(stripLeadingPlus(msisdn)).child(id).removeValueAsync()
     }
 
 

--- a/prime/src/main/kotlin/org/ostelco/prime/firebase/FbStorage.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/firebase/FbStorage.kt
@@ -130,9 +130,10 @@ constructor(databaseName: String,
         return facade.injectPurchaseRequest(pr)
     }
 
-    override fun removeRecordOfPurchaseById(id: String) {
+    override fun removeRecordOfPurchaseById(purchase: RecordOfPurchase, id: String) {
         checkNotNull(id)
-        facade.removeRecordOfPurchaseById(id)
+        checkNotNull(purchase)
+        facade.removeRecordOfPurchaseById(purchase, id)
     }
 
     override fun addRecordOfPurchase(purchase: RecordOfPurchase): String {

--- a/prime/src/main/kotlin/org/ostelco/prime/firebase/FbStorage.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/firebase/FbStorage.kt
@@ -130,10 +130,10 @@ constructor(databaseName: String,
         return facade.injectPurchaseRequest(pr)
     }
 
-    override fun removeRecordOfPurchaseById(purchase: RecordOfPurchase, id: String) {
+    override fun removeRecordOfPurchaseById(msisdn: String, id: String) {
         checkNotNull(id)
-        checkNotNull(purchase)
-        facade.removeRecordOfPurchaseById(purchase, id)
+        checkNotNull(msisdn)
+        facade.removeRecordOfPurchaseById(msisdn, id)
     }
 
     override fun addRecordOfPurchase(purchase: RecordOfPurchase): String {

--- a/prime/src/main/kotlin/org/ostelco/prime/storage/Storage.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/storage/Storage.kt
@@ -44,5 +44,5 @@ interface Storage : ProductDescriptionCache {
 
     fun removePurchaseRequestById(id: String)
 
-    fun removeRecordOfPurchaseById(purchase: RecordOfPurchase, id: String)
+    fun removeRecordOfPurchaseById(msisdn: String, id: String)
 }

--- a/prime/src/main/kotlin/org/ostelco/prime/storage/Storage.kt
+++ b/prime/src/main/kotlin/org/ostelco/prime/storage/Storage.kt
@@ -44,5 +44,5 @@ interface Storage : ProductDescriptionCache {
 
     fun removePurchaseRequestById(id: String)
 
-    fun removeRecordOfPurchaseById(id: String)
+    fun removeRecordOfPurchaseById(purchase: RecordOfPurchase, id: String)
 }


### PR DESCRIPTION
Now the purchase request is stored on random fb key. This will instead store it on the path:

records-of-purchase/{msisdn}/{id}

This will make it easier to fetch the users previous purchase records