### PR TITLE
Firebase Cloud messaging API

### DIFF
--- a/acceptance-tests/src/main/kotlin/org/ostelco/at/jersey/Tests.kt
+++ b/acceptance-tests/src/main/kotlin/org/ostelco/at/jersey/Tests.kt
@@ -196,5 +196,9 @@ class ProfileTest {
             path = "/applicationtoken"
             body = testToken
         }
+
+        assertEquals(token, reply.token, "Incorrect token in reply after posting new token")
+        assertEquals(applicationId, reply.applicationID, "Incorrect applicationId in reply after posting new token")
+        assertEquals(tokenType, reply.tokenType, "Incorrect tokenType in reply after posting new token")
     }
 }

--- a/acceptance-tests/src/main/kotlin/org/ostelco/at/jersey/Tests.kt
+++ b/acceptance-tests/src/main/kotlin/org/ostelco/at/jersey/Tests.kt
@@ -8,7 +8,9 @@ import org.ostelco.prime.client.model.Product
 import org.ostelco.prime.client.model.Profile
 import org.ostelco.prime.client.model.SubscriptionStatus
 import org.ostelco.prime.logger
+import org.ostelco.prime.model.ApplicationToken
 import java.time.Instant
+import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -179,5 +181,20 @@ class ProfileTest {
         assertEquals("", clearedProfile.postCode, "Incorrect 'postcode' in response after clearing profile")
         assertEquals("", clearedProfile.city, "Incorrect 'city' in response after clearing profile")
         assertEquals("", clearedProfile.country, "Incorrect 'country' in response after clearing profile")
+    }
+
+    @Test
+    fun testApplicationToken() {
+
+        val token = UUID.randomUUID().toString()
+        val applicationId = "testApplicationId"
+        val tokenType = "FCM"
+
+        val testToken = ApplicationToken(token, applicationId, tokenType)
+
+        val reply: ApplicationToken = post {
+            path = "/applicationtoken"
+            body = testToken
+        }
     }
 }

--- a/app-notifier/src/main/kotlin/org/ostelco/prime/appnotifier/FirebaseAppNotifier.kt
+++ b/app-notifier/src/main/kotlin/org/ostelco/prime/appnotifier/FirebaseAppNotifier.kt
@@ -27,14 +27,16 @@ class FirebaseAppNotifier: AppNotifier {
         val store = getResource<Storage>()
 
         // This registration token comes from the client FCM SDKs.
-        val applicationToken = store.getNotificationToken(msisdn)
+        val applicationTokens = store.getNotificationTokens(msisdn)
 
-        if (applicationToken != null) {
+        for (applicationToken in applicationTokens) {
+
+            // ToDo : Currently we asume that all tokens are for FCM
 
             // See documentation on defining a message payload.
             val message = Message.builder()
                     .setNotification(Notification(title, body))
-                    .setToken(applicationToken)
+                    .setToken(applicationToken.token)
                     .build()
 
             // Send a message to the device corresponding to the provided
@@ -54,8 +56,6 @@ class FirebaseAppNotifier: AppNotifier {
             }
 
             addCallback(future, apiFutureCallback)
-        } else {
-            println("Not able to fetch notification token for msisdn : $msisdn")
         }
     }
 }

--- a/client-api/src/main/kotlin/org/ostelco/prime/client/api/TopupModule.kt
+++ b/client-api/src/main/kotlin/org/ostelco/prime/client/api/TopupModule.kt
@@ -13,11 +13,7 @@ import io.dropwizard.client.JerseyClientBuilder
 import io.dropwizard.setup.Environment
 import org.ostelco.prime.client.api.auth.AccessTokenPrincipal
 import org.ostelco.prime.client.api.auth.OAuthAuthenticator
-import org.ostelco.prime.client.api.resources.AnalyticsResource
-import org.ostelco.prime.client.api.resources.ConsentsResource
-import org.ostelco.prime.client.api.resources.ProductsResource
-import org.ostelco.prime.client.api.resources.ProfileResource
-import org.ostelco.prime.client.api.resources.SubscriptionResource
+import org.ostelco.prime.client.api.resources.*
 import org.ostelco.prime.client.api.store.SubscriberDAOImpl
 import org.ostelco.prime.logger
 import org.ostelco.prime.module.PrimeModule
@@ -57,6 +53,7 @@ class TopupModule : PrimeModule {
         jerseyEnv.register(ProductsResource(dao))
         jerseyEnv.register(ProfileResource(dao))
         jerseyEnv.register(SubscriptionResource(dao, client, config.pseudonymEndpoint!!))
+        jerseyEnv.register(ApplicationTokenResource(dao))
 
         /* For reporting OAuth2 caching events. */
         val metrics = SharedMetricRegistries.getOrCreate(env.getName())

--- a/client-api/src/main/kotlin/org/ostelco/prime/client/api/resources/ApplicationTokenResource.kt
+++ b/client-api/src/main/kotlin/org/ostelco/prime/client/api/resources/ApplicationTokenResource.kt
@@ -25,23 +25,22 @@ class ApplicationTokenResource(private val dao: SubscriberDAO) : ResourceHelpers
                     .build()
         }
 
-        val msisdn = dao.getMsisdn(authToken.name)
+        val result = dao.getMsisdn(authToken.name)
 
-        if (msisdn.isRight) {
-            val m = msisdn.right().get()
-            println("ApplicationTokenResource called with msisdn : $m")
+        if (result.isRight) {
+            val msisdn = result.right().get()
+            val created = dao.storeApplicationToken(msisdn, applicationToken)
+            if (created.isRight) {
+                return Response.status(Response.Status.CREATED)
+                        .entity(asJson(created.right().get()))
+                        .build()
+            } else {
+                return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                        .entity(asJson(created.left().get()))
+                        .build()
+            }
         } else {
-            println("ApplicationTokenResource could not find subscriper msisdn")
-        }
-
-        val result = dao.getSubscriptionStatus(authToken.name)
-
-        return if (result.isRight) {
-            Response.status(Response.Status.CREATED)
-                    .entity(asJson(result.right().get()))
-                    .build()
-        } else {
-            Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                     .entity(asJson(result.left().get()))
                     .build()
         }

--- a/client-api/src/main/kotlin/org/ostelco/prime/client/api/resources/ApplicationTokenResource.kt
+++ b/client-api/src/main/kotlin/org/ostelco/prime/client/api/resources/ApplicationTokenResource.kt
@@ -35,12 +35,12 @@ class ApplicationTokenResource(private val dao: SubscriberDAO) : ResourceHelpers
                         .entity(asJson(created.right().get()))
                         .build()
             } else {
-                return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                return Response.status(507) // Insufficient Storage
                         .entity(asJson(created.left().get()))
                         .build()
             }
         } else {
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+            return Response.status(Response.Status.NOT_FOUND)
                     .entity(asJson(result.left().get()))
                     .build()
         }

--- a/client-api/src/main/kotlin/org/ostelco/prime/client/api/resources/ApplicationTokenResource.kt
+++ b/client-api/src/main/kotlin/org/ostelco/prime/client/api/resources/ApplicationTokenResource.kt
@@ -1,0 +1,44 @@
+package org.ostelco.prime.client.api.resources
+
+import io.dropwizard.auth.Auth
+import org.ostelco.prime.client.api.auth.AccessTokenPrincipal
+import org.ostelco.prime.client.api.store.SubscriberDAO
+import org.ostelco.prime.model.ApplicationToken
+import javax.validation.constraints.NotNull
+import javax.ws.rs.*
+import javax.ws.rs.core.Response
+
+/**
+ * ApplicationToken API.
+ *
+ */
+@Path("/applicationtoken")
+class ApplicationTokenResource(private val dao: SubscriberDAO) : ResourceHelpers() {
+
+    @POST
+    @Produces("application/json")
+    @Consumes("application/json")
+    fun storeApplicationToken(@Auth authToken: AccessTokenPrincipal?,
+                      @NotNull applicationToken: ApplicationToken): Response {
+        if (authToken == null) {
+            return Response.status(Response.Status.UNAUTHORIZED)
+                    .build()
+        }
+
+        val msisdn = dao.getMsisdn(authToken.name)
+
+        println("ApplicationTokenResource called with msisdn : $msisdn and applicationToken : $applicationToken")
+
+        val result = dao.getSubscriptionStatus(authToken.name)
+
+        return if (result.isRight) {
+            Response.status(Response.Status.CREATED)
+                    .entity(asJson(result.right().get()))
+                    .build()
+        } else {
+            Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(asJson(result.left().get()))
+                    .build()
+        }
+    }
+}

--- a/client-api/src/main/kotlin/org/ostelco/prime/client/api/resources/ApplicationTokenResource.kt
+++ b/client-api/src/main/kotlin/org/ostelco/prime/client/api/resources/ApplicationTokenResource.kt
@@ -27,7 +27,12 @@ class ApplicationTokenResource(private val dao: SubscriberDAO) : ResourceHelpers
 
         val msisdn = dao.getMsisdn(authToken.name)
 
-        println("ApplicationTokenResource called with msisdn : $msisdn and applicationToken : $applicationToken")
+        if (msisdn.isRight) {
+            val m = msisdn.right().get()
+            println("ApplicationTokenResource called with msisdn : $m")
+        } else {
+            println("ApplicationTokenResource could not find subscriper msisdn")
+        }
 
         val result = dao.getSubscriptionStatus(authToken.name)
 

--- a/client-api/src/main/kotlin/org/ostelco/prime/client/api/store/SubscriberDAO.kt
+++ b/client-api/src/main/kotlin/org/ostelco/prime/client/api/store/SubscriberDAO.kt
@@ -5,6 +5,7 @@ import io.vavr.control.Option
 import org.ostelco.prime.client.api.core.ApiError
 import org.ostelco.prime.client.api.model.Consent
 import org.ostelco.prime.client.api.model.SubscriptionStatus
+import org.ostelco.prime.model.ApplicationToken
 import org.ostelco.prime.model.Product
 import org.ostelco.prime.model.Subscriber
 
@@ -34,6 +35,8 @@ interface SubscriberDAO {
     fun rejectConsent(subscriptionId: String, consentId: String): Either<ApiError, Consent>
 
     fun reportAnalytics(subscriptionId: String, events: String): Option<ApiError>
+
+    fun storeApplicationToken(subscriptionId: String, token: ApplicationToken): Either<ApiError, ApplicationToken>
 
     companion object {
 

--- a/client-api/src/main/kotlin/org/ostelco/prime/client/api/store/SubscriberDAO.kt
+++ b/client-api/src/main/kotlin/org/ostelco/prime/client/api/store/SubscriberDAO.kt
@@ -36,7 +36,7 @@ interface SubscriberDAO {
 
     fun reportAnalytics(subscriptionId: String, events: String): Option<ApiError>
 
-    fun storeApplicationToken(subscriptionId: String, token: ApplicationToken): Either<ApiError, ApplicationToken>
+    fun storeApplicationToken(subscriptionId: String, applicationToken: ApplicationToken): Either<ApiError, ApplicationToken>
 
     companion object {
 

--- a/client-api/src/main/kotlin/org/ostelco/prime/client/api/store/SubscriberDAOImpl.kt
+++ b/client-api/src/main/kotlin/org/ostelco/prime/client/api/store/SubscriberDAOImpl.kt
@@ -66,16 +66,10 @@ class SubscriberDAOImpl(private val storage: Storage, private val ocsSubscriberS
     }
 
     override fun storeApplicationToken(subscriptionId: String, applicationToken: ApplicationToken): Either<ApiError, ApplicationToken> {
-
-        println("storeApplicationToken called")
-        val result = getMsisdn(subscriptionId)
-
-        if (result.isRight) {
-            val msisdn = result.right().get()
-            storage.addNotificationToken(msisdn, applicationToken.token)
+        if ( storage.addNotificationToken(subscriptionId, applicationToken) ) {
             return Either.right(applicationToken)
         } else {
-            return Either.left(ApiError("User not found"))
+            return Either.left(ApiError("Failed to store ApplicationToken"))
         }
     }
 

--- a/client-api/src/main/kotlin/org/ostelco/prime/client/api/store/SubscriberDAOImpl.kt
+++ b/client-api/src/main/kotlin/org/ostelco/prime/client/api/store/SubscriberDAOImpl.kt
@@ -6,6 +6,7 @@ import org.ostelco.prime.client.api.core.ApiError
 import org.ostelco.prime.client.api.model.Consent
 import org.ostelco.prime.client.api.model.SubscriptionStatus
 import org.ostelco.prime.logger
+import org.ostelco.prime.model.ApplicationToken
 import org.ostelco.prime.model.Product
 import org.ostelco.prime.model.PurchaseRecord
 import org.ostelco.prime.model.Subscriber
@@ -62,6 +63,20 @@ class SubscriberDAOImpl(private val storage: Storage, private val ocsSubscriberS
         }
 
         return getProfile(subscriptionId)
+    }
+
+    override fun storeApplicationToken(subscriptionId: String, token: ApplicationToken): Either<ApiError, ApplicationToken> {
+
+        println("storeApplicationToken called")
+        val result = getMsisdn(subscriptionId)
+
+        if (result.isRight) {
+            val msisdn = result.right().get()
+            storage.addNotificationToken(msisdn, token.token)
+            return Either.right(token)
+        } else {
+            return Either.left(ApiError("User not found"))
+        }
     }
 
     override fun updateProfile(subscriptionId: String, profile: Subscriber): Either<ApiError, Subscriber> {

--- a/client-api/src/main/kotlin/org/ostelco/prime/client/api/store/SubscriberDAOImpl.kt
+++ b/client-api/src/main/kotlin/org/ostelco/prime/client/api/store/SubscriberDAOImpl.kt
@@ -65,15 +65,15 @@ class SubscriberDAOImpl(private val storage: Storage, private val ocsSubscriberS
         return getProfile(subscriptionId)
     }
 
-    override fun storeApplicationToken(subscriptionId: String, token: ApplicationToken): Either<ApiError, ApplicationToken> {
+    override fun storeApplicationToken(subscriptionId: String, applicationToken: ApplicationToken): Either<ApiError, ApplicationToken> {
 
         println("storeApplicationToken called")
         val result = getMsisdn(subscriptionId)
 
         if (result.isRight) {
             val msisdn = result.right().get()
-            storage.addNotificationToken(msisdn, token.token)
-            return Either.right(token)
+            storage.addNotificationToken(msisdn, applicationToken.token)
+            return Either.right(applicationToken)
         } else {
             return Either.left(ApiError("User not found"))
         }

--- a/client-api/src/test/kotlin/org/ostelco/prime/client/api/resources/ApplicationTokenResourceTest.kt
+++ b/client-api/src/test/kotlin/org/ostelco/prime/client/api/resources/ApplicationTokenResourceTest.kt
@@ -38,6 +38,8 @@ class ApplicationTokenResourceTest {
     private val applicationID = "myAppID:4378932"
     private val tokenType = "FCM"
 
+    private val applicationToken = ApplicationToken()
+
     @Before
     @Throws(Exception::class)
     fun setUp() {
@@ -51,10 +53,9 @@ class ApplicationTokenResourceTest {
         val arg1 = argumentCaptor<String>()
         val arg2 = argumentCaptor<ApplicationToken>()
 
-        /*
-        `when`(DAO.createProfile(arg1.capture(), arg2.capture()))
-                .thenReturn(Either.right(profile))
-        */
+        `when`(DAO.storeApplicationToken(arg1.capture(), arg2.capture()))
+                .thenReturn(Either.right(applicationToken))
+
         val resp = RULE.target("/applicationtoken")
                 .request(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
@@ -84,7 +85,7 @@ class ApplicationTokenResourceTest {
                                 .setPrefix("Bearer")
                                 .buildAuthFilter()))
                 .addResource(AuthValueFactoryProvider.Binder(AccessTokenPrincipal::class.java))
-                .addResource(ProfileResource(DAO))
+                .addResource(ApplicationTokenResource(DAO))
                 .setTestContainerFactory(GrizzlyWebTestContainerFactory())
                 .build()
     }

--- a/client-api/src/test/kotlin/org/ostelco/prime/client/api/resources/ApplicationTokenResourceTest.kt
+++ b/client-api/src/test/kotlin/org/ostelco/prime/client/api/resources/ApplicationTokenResourceTest.kt
@@ -70,17 +70,18 @@ class ApplicationTokenResourceTest {
                         "    \"tokenType\": \"" + tokenType + "\"\n" +
                         "}\n"))
 
-        println("Response is $resp")
         assertThat(resp.status).isEqualTo(Response.Status.CREATED.statusCode)
         assertThat(resp.mediaType.toString()).isEqualTo(MediaType.APPLICATION_JSON)
-        assertThat(arg1.firstValue).isEqualTo(email)
+        assertThat(arg1.firstValue).isEqualTo(msisdn)
+        assertThat(arg2.firstValue.token).isEqualTo(token)
+        assertThat(arg2.firstValue.applicationID).isEqualTo(applicationID)
+        assertThat(arg2.firstValue.tokenType).isEqualTo(tokenType)
     }
 
     companion object {
 
         val DAO = mock(SubscriberDAO::class.java)
         val AUTHENTICATOR = mock(OAuthAuthenticator::class.java)
-        val PSEUDONYMENDPOINT = "http://localhost"
         val client: Client = mock(Client::class.java)
 
         @JvmField

--- a/client-api/src/test/kotlin/org/ostelco/prime/client/api/resources/ApplicationTokenResourceTest.kt
+++ b/client-api/src/test/kotlin/org/ostelco/prime/client/api/resources/ApplicationTokenResourceTest.kt
@@ -1,0 +1,91 @@
+package org.ostelco.prime.client.api.resources
+
+import com.nhaarman.mockito_kotlin.argumentCaptor
+import io.dropwizard.auth.AuthDynamicFeature
+import io.dropwizard.auth.AuthValueFactoryProvider
+import io.dropwizard.auth.oauth.OAuthCredentialAuthFilter
+import io.dropwizard.testing.junit.ResourceTestRule
+import io.vavr.control.Either
+import org.assertj.core.api.Assertions.assertThat
+import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory
+import org.junit.Before
+import org.junit.ClassRule
+import org.junit.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.ostelco.prime.client.api.auth.AccessTokenPrincipal
+import org.ostelco.prime.client.api.auth.OAuthAuthenticator
+import org.ostelco.prime.client.api.core.ApiError
+import org.ostelco.prime.client.api.store.SubscriberDAO
+import org.ostelco.prime.client.api.util.AccessToken
+import org.ostelco.prime.model.ApplicationToken
+import org.ostelco.prime.model.Subscriber
+import java.util.*
+import javax.ws.rs.client.Entity
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Response
+
+/**
+ * ApplicationToken API tests.
+ *
+ */
+class ApplicationTokenResourceTest {
+
+    private val email = "boaty@internet.org"
+
+    private val token = "testToken:kshfkajhka"
+    private val applicationID = "myAppID:4378932"
+    private val tokenType = "FCM"
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        `when`(AUTHENTICATOR.authenticate(ArgumentMatchers.anyString()))
+                .thenReturn(Optional.of(AccessTokenPrincipal(email)))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun storeApplicationToken() {
+        val arg1 = argumentCaptor<String>()
+        val arg2 = argumentCaptor<ApplicationToken>()
+
+        /*
+        `when`(DAO.createProfile(arg1.capture(), arg2.capture()))
+                .thenReturn(Either.right(profile))
+        */
+        val resp = RULE.target("/applicationtoken")
+                .request(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer ${AccessToken.withEmail(email)}")
+                .post(Entity.json("{\n" +
+                        "    \"token\": \"" + token + "\",\n" +
+                        "    \"applicationID\": \"" + applicationID + "\",\n" +
+                        "    \"tokenType\": \"" + tokenType + "\",\n" +
+                        "}\n"))
+
+        assertThat(resp.status).isEqualTo(Response.Status.CREATED.statusCode)
+        assertThat(resp.mediaType.toString()).isEqualTo(MediaType.APPLICATION_JSON)
+        assertThat(arg1.firstValue).isEqualTo(email)
+    }
+
+    companion object {
+
+        val DAO = mock(SubscriberDAO::class.java)
+        val AUTHENTICATOR = mock(OAuthAuthenticator::class.java)
+
+        @JvmField
+        @ClassRule
+        val RULE = ResourceTestRule.builder()
+                .addResource(AuthDynamicFeature(
+                        OAuthCredentialAuthFilter.Builder<AccessTokenPrincipal>()
+                                .setAuthenticator(AUTHENTICATOR)
+                                .setPrefix("Bearer")
+                                .buildAuthFilter()))
+                .addResource(AuthValueFactoryProvider.Binder(AccessTokenPrincipal::class.java))
+                .addResource(ProfileResource(DAO))
+                .setTestContainerFactory(GrizzlyWebTestContainerFactory())
+                .build()
+    }
+}

--- a/model/src/main/kotlin/org/ostelco/prime/model/Entities.kt
+++ b/model/src/main/kotlin/org/ostelco/prime/model/Entities.kt
@@ -38,6 +38,11 @@ data class Subscriber(
         }
 }
 
+data class ApplicationToken(
+        var token: String = "",
+        var applicationID: String = "",
+        var tokenType: String = "")
+
 data class Price(
         var amount: Int = 0,
         var currency: String = "")

--- a/model/src/main/kotlin/org/ostelco/prime/model/Entities.kt
+++ b/model/src/main/kotlin/org/ostelco/prime/model/Entities.kt
@@ -41,7 +41,20 @@ data class Subscriber(
 data class ApplicationToken(
         var token: String = "",
         var applicationID: String = "",
-        var tokenType: String = "")
+        var tokenType: String = "") : Entity {
+
+    constructor(applicationID: String) : this() {
+        this.applicationID = applicationID
+    }
+
+    override var id: String
+        @JsonIgnore
+        get() = applicationID
+        @JsonIgnore
+        set(value) {
+            applicationID = value
+        }
+}
 
 data class Price(
         var amount: Int = 0,

--- a/ocs/src/main/kotlin/org/ostelco/prime/disruptor/PrimeEventProducer.kt
+++ b/ocs/src/main/kotlin/org/ostelco/prime/disruptor/PrimeEventProducer.kt
@@ -10,8 +10,7 @@ interface PrimeEventProducer {
     fun releaseReservedDataBucketEvent(
             msisdn: String,
             bytes: Long)
-
-    // FixMe : For now we assume that there is only 1 MSCC in the Request.
+    
     fun injectCreditControlRequestIntoRingbuffer(
             request: CreditControlRequestInfo,
             streamId: String)

--- a/ocs/src/main/kotlin/org/ostelco/prime/disruptor/PrimeEventProducerImpl.kt
+++ b/ocs/src/main/kotlin/org/ostelco/prime/disruptor/PrimeEventProducerImpl.kt
@@ -87,7 +87,6 @@ class PrimeEventProducerImpl(private val ringBuffer: RingBuffer<PrimeEvent>) : P
                 requestedBytes = bytes)
     }
 
-    // FixMe : For now we assume that there is only 1 MSCC in the Request.
     override fun injectCreditControlRequestIntoRingbuffer(
             request: CreditControlRequestInfo,
             streamId: String) {
@@ -98,6 +97,7 @@ class PrimeEventProducerImpl(private val ringBuffer: RingBuffer<PrimeEvent>) : P
                     streamId = streamId,
                     requestId = request.requestId)
         } else {
+            // FixMe : For now we assume that there is only 1 MSCC in the Request.
             injectIntoRingbuffer(CREDIT_CONTROL_REQUEST,
                     msisdn = request.msisdn,
                     requestedBytes = request.getMscc(0).requested.totalOctets,

--- a/prime-api/src/main/kotlin/org/ostelco/prime/storage/legacy/Storage.kt
+++ b/prime-api/src/main/kotlin/org/ostelco/prime/storage/legacy/Storage.kt
@@ -1,5 +1,6 @@
 package org.ostelco.prime.storage.legacy
 
+import org.ostelco.prime.model.ApplicationToken
 import org.ostelco.prime.model.Product
 import org.ostelco.prime.model.PurchaseRecord
 import org.ostelco.prime.model.Subscriber
@@ -97,10 +98,11 @@ interface Storage {
     /**
      * Get token used for sending notification to user application
      */
-    fun getNotificationToken(msisdn : String): String?
+    fun getNotificationTokens(msisdn : String): Collection<ApplicationToken>
 
     /**
      * Add token used for sending notification to user application
      */
-    fun addNotificationToken(msisdn: String, token: String)
+    fun addNotificationToken(msisdn: String, token: ApplicationToken) : Boolean
+
 }

--- a/prime-api/src/main/kotlin/org/ostelco/prime/storage/legacy/Storage.kt
+++ b/prime-api/src/main/kotlin/org/ostelco/prime/storage/legacy/Storage.kt
@@ -105,4 +105,5 @@ interface Storage {
      */
     fun addNotificationToken(msisdn: String, token: ApplicationToken) : Boolean
 
+    fun getNotificationToken(msisdn: String, applicationID: String): ApplicationToken?
 }

--- a/prime/infra/prime-client-api.yaml
+++ b/prime/infra/prime-client-api.yaml
@@ -64,6 +64,27 @@ paths:
           description: "Profile not found."
       security:
         - auth0_jwt: []
+  "/applicationtoken":
+    post:
+      description: "Store application token"
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: "storeApplicationToken"
+      parameters:
+        - name: applicationToken
+          in: body
+          description: application token
+          schema:
+            $ref: '#/definitions/ApplicationToken'
+      responses:
+        201:
+          description: "Successfully stored token."
+        500:
+          description: "Not able to store token."
+      security:
+        - auth0_jwt: []
   "/products":
     get:
       description: "Get all products for the user."
@@ -262,6 +283,21 @@ definitions:
     required:
       - amount
       - currency
+  ApplicationToken:
+    type: object
+    properties:
+      token:
+        description: "Application token"
+        type: string
+      applicationID:
+        description: "Uniquely identifier for the app instance"
+        type: string
+      tokenType:
+        description: "Type of application token (FCM)"
+        type: string
+    required:
+      - token
+      - applicationID
   PseudonymEntity:
     type: object
     properties:

--- a/prime/infra/prime-client-api.yaml
+++ b/prime/infra/prime-client-api.yaml
@@ -81,7 +81,11 @@ paths:
       responses:
         201:
           description: "Successfully stored token."
-        500:
+          schema:
+            $ref: '#/definitions/ApplicationToken'
+        404:
+          description: "User not found."
+        507:
           description: "Not able to store token."
       security:
         - auth0_jwt: []


### PR DESCRIPTION
Continuation of https://github.com/ostelco/ostelco-core/pull/156

Added an API for storing FCM tokens.

The token is unique per application/user. And is stored in Firebase under node:

    applicationToken/{msisdn}/{applicationId}

The client is responsible for storing the token and updating it if it is changed.