### PR TITLE
Remove application token when not usable

### DIFF
--- a/client-api/src/main/kotlin/org/ostelco/prime/client/api/store/SubscriberDAOImpl.kt
+++ b/client-api/src/main/kotlin/org/ostelco/prime/client/api/store/SubscriberDAOImpl.kt
@@ -75,7 +75,7 @@ class SubscriberDAOImpl(private val storage: Storage, private val ocsSubscriberS
         return getNotificationToken(msisdn, applicationToken.applicationID)
     }
 
-    fun getNotificationToken(msisdn: String, applicationId: String): Either<ApiError, ApplicationToken> {
+    private fun getNotificationToken(msisdn: String, applicationId: String): Either<ApiError, ApplicationToken> {
         try {
             return storage.getNotificationToken(msisdn, applicationId)
                     ?.let { Either.right<ApiError, ApplicationToken>(it) }

--- a/firebase-store/src/main/kotlin/org/ostelco/prime/storage/firebase/FirebaseStorage.kt
+++ b/firebase-store/src/main/kotlin/org/ostelco/prime/storage/firebase/FirebaseStorage.kt
@@ -154,6 +154,10 @@ object FirebaseStorageSingleton : Storage {
             databaseReference.child(urlEncode(msisdn))
         }.values
     }
+
+    override fun removeNotificationToken(msisdn: String, applicationID: String): Boolean {
+        return fcmTokenStore.delete(applicationID) { databaseReference.child(urlEncode(msisdn)) }
+    }
 }
 
 private val config = FirebaseConfigRegistry.firebaseConfig
@@ -312,11 +316,11 @@ class EntityStore<E>(
      *
      * @return success
      */
-    fun delete(id: String, dontExists: Boolean = dontExists(id)): Boolean {
+    fun delete(id: String, dontExists: Boolean = dontExists(id), reference: EntityStore<E>.() -> DatabaseReference = { databaseReference }): Boolean {
         if (dontExists) {
             return false
         }
-        val future = databaseReference.child(urlEncode(id)).removeValueAsync()
+        val future = reference().child(urlEncode(id)).removeValueAsync()
         // FIXME this may always return false
         future.get(TIMEOUT, SECONDS) ?: return false
         return true

--- a/prime-api/src/main/kotlin/org/ostelco/prime/storage/legacy/Storage.kt
+++ b/prime-api/src/main/kotlin/org/ostelco/prime/storage/legacy/Storage.kt
@@ -99,5 +99,13 @@ interface Storage {
      */
     fun addNotificationToken(msisdn: String, token: ApplicationToken) : Boolean
 
+    /**
+     * Get token used for sending notification to user application
+     */
     fun getNotificationToken(msisdn: String, applicationID: String): ApplicationToken?
+
+    /**
+     * Get token used for sending notification to user application
+     */
+    fun removeNotificationToken(msisdn: String, applicationID: String): Boolean
 }


### PR DESCRIPTION
If the call to use the notification token indicate that the token
is no longer in use it is removed from the DB.