### PR TITLE
Temporarily added legacy purchase operation without payment

### DIFF
--- a/acceptance-tests/src/main/kotlin/org/ostelco/at/okhttp/Tests.kt
+++ b/acceptance-tests/src/main/kotlin/org/ostelco/at/okhttp/Tests.kt
@@ -76,8 +76,6 @@ class ProfileTest {
 
 class GetSubscriptions {
 
-    private val logger by logger()
-
     @Test
     fun `okhttp test - GET subscriptions`() {
 
@@ -167,8 +165,6 @@ class GetProductsTest {
 
 class PurchaseTest {
 
-    private val logger by logger()
-
     @Test
     fun `okhttp test - POST products purchase`() {
 
@@ -182,6 +178,32 @@ class PurchaseTest {
         val sourceId = createPaymentSourceId()
 
         client.purchaseProduct("1GB_249NOK", sourceId, false)
+
+        Thread.sleep(200) // wait for 200 ms for balance to be updated in db
+
+        val balanceAfter = client.subscriptionStatus.remaining
+
+        assertEquals(1_000_000_000, balanceAfter - balanceBefore, "Balance did not increased by 1GB after Purchase")
+
+        val purchaseRecords = client.purchaseHistory
+
+        purchaseRecords.sortBy { it.timestamp }
+
+        assert(Instant.now().toEpochMilli() - purchaseRecords.last().timestamp < 10_000) { "Missing Purchase Record" }
+        assertEquals(expectedProducts().first(), purchaseRecords.last().product, "Incorrect 'Product' in purchase record")
+    }
+
+    @Test
+    fun `okhttp test - POST products purchase without payment`() {
+
+        val email = "purchase-legacy-${randomInt()}@test.com"
+        createProfile(name = "Test Legacy Purchase User", email = email)
+
+        val client = clientForSubject(subject = email)
+
+        val balanceBefore = client.subscriptionStatus.remaining
+
+        client.buyProductDeprecated("1GB_249NOK")
 
         Thread.sleep(200) // wait for 200 ms for balance to be updated in db
 

--- a/client-api/src/main/kotlin/org/ostelco/prime/client/api/resources/ProductsResource.kt
+++ b/client-api/src/main/kotlin/org/ostelco/prime/client/api/resources/ProductsResource.kt
@@ -38,14 +38,21 @@ class ProductsResource(private val dao: SubscriberDAO) {
     @POST
     @Path("{sku}")
     @Produces("application/json")
-    fun purchaseProductOld(@Auth token: AccessTokenPrincipal?,
-                           @NotNull
-                           @PathParam("sku")
-                           sku: String,
-                           @QueryParam("sourceId")
-                           sourceId: String?,
-                           @QueryParam("saveCard")
-                           saveCard: Boolean = false): Response = purchaseProduct(token, sku, sourceId, saveCard)
+    fun purchaseProductWithoutPayment(@Auth token: AccessTokenPrincipal?,
+                                      @NotNull
+                                      @PathParam("sku")
+                                      sku: String): Response {
+        if (token == null) {
+            return Response.status(Response.Status.UNAUTHORIZED)
+                    .build()
+        }
+
+        return dao.purchaseProductWithoutPayment(token.name, sku)
+                .fold(
+                        { apiError -> Response.status(apiError.status).entity(asJson(apiError.description)) },
+                        { productInfo -> Response.status(CREATED).entity(productInfo) }
+                ).build()
+    }
 
     @POST
     @Path("{sku}/purchase")
@@ -66,8 +73,7 @@ class ProductsResource(private val dao: SubscriberDAO) {
         return dao.purchaseProduct(token.name, sku, sourceId, saveCard)
                 .fold(
                         { apiError -> Response.status(apiError.status).entity(asJson(apiError.description)) },
-                        { productInfo -> Response.status(CREATED).entity(productInfo)}
+                        { productInfo -> Response.status(CREATED).entity(productInfo) }
                 ).build()
-
     }
 }

--- a/client-api/src/main/kotlin/org/ostelco/prime/client/api/store/SubscriberDAO.kt
+++ b/client-api/src/main/kotlin/org/ostelco/prime/client/api/store/SubscriberDAO.kt
@@ -87,4 +87,7 @@ interface SubscriberDAO {
                     && !appToken.tokenType.isEmpty())
         }
     }
+
+    @Deprecated(message = "use purchaseProduct")
+    fun purchaseProductWithoutPayment(subscriberId: String, sku: String): Either<ApiError, Unit>
 }


### PR DESCRIPTION
This legacy operation is added so that the existing app will work and prime can be deployed to production. The new payment is available on a new REST endpoint.