### PR TITLE
Use a fixed version of google-cloud-sdk docker image

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -91,7 +91,7 @@ services:
 
   datastore-emulator:
     container_name: datastore-emulator
-    image: google/cloud-sdk
+    image: google/cloud-sdk:206.0.0
     expose:
     - "8081"
     environment:


### PR DESCRIPTION
In the latest version of the docker image, there is a JAVA version
mismatch which is preventing us from running datastore emulator.
So for the time being lets use a tested one.