### PR TITLE
Use the pubsub emulator while doing acceptance tests

### DIFF
--- a/analytics-module/build.gradle
+++ b/analytics-module/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     implementation "io.dropwizard:dropwizard-core:$dropwizardVersion"
     implementation "com.google.cloud:google-cloud-pubsub:$googleCloudVersion"
     implementation 'com.google.code.gson:gson:2.8.5'
+    //compile group: 'com.google.api', name: 'gax-grpc', version: '0.14.0'
+    testCompile group: 'com.google.api', name: 'gax-grpc', version: '1.30.0'
 
     testImplementation "io.dropwizard:dropwizard-testing:$dropwizardVersion"
     testImplementation 'org.mockito:mockito-core:2.18.3'

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -8,7 +8,6 @@ services:
       dockerfile: Dockerfile.test
     environment:
     - FIREBASE_ROOT_PATH=test
-    - GOOGLE_APPLICATION_CREDENTIALS=/secret/pantel-prod.json
     - PUBSUB_EMULATOR_HOST=pubsub-emulator:8085
     - PUBSUB_PROJECT_ID=pantel-2decb
     - STRIPE_API_KEY=${STRIPE_API_KEY}

--- a/prime/script/wait.sh
+++ b/prime/script/wait.sh
@@ -39,6 +39,7 @@ curl  -X PUT pubsub-emulator:8085/v1/projects/pantel-2decb/topics/data-traffic
 curl  -X PUT pubsub-emulator:8085/v1/projects/pantel-2decb/topics/pseudo-traffic
 curl -X PUT -H "Content-Type: application/json" -d '{"topic":"projects/pantel-2decb/topics/data-traffic","ackDeadlineSeconds":10}' pubsub-emulator:8085/v1/projects/pantel-2decb/subscriptions/test-pseudo
 curl  -X PUT pubsub-emulator:8085/v1/projects/pantel-2decb/topics/purchase-info
+curl -X PUT -H "Content-Type: application/json" -d '{"topic":"projects/pantel-2decb/topics/purchase-info","ackDeadlineSeconds":10}' pubsub-emulator:8085/v1/projects/pantel-2decb/subscriptions/purchase-info-sub
 
 echo "Done creating topics and subscriptions"
 


### PR DESCRIPTION
We were pushing records to the Pub/Sub in production GCP 