### PR TITLE
Revert back to openjdk image.

### DIFF
--- a/bq-metrics-extractor/Dockerfile
+++ b/bq-metrics-extractor/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM openjdk:8u171
 
 MAINTAINER CSI "csi@telenordigital.com"
 

--- a/bq-metrics-extractor/Dockerfile.test
+++ b/bq-metrics-extractor/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM openjdk:8u171
 
 MAINTAINER CSI "csi@telenordigital.com"
 


### PR DESCRIPTION
The alpine version dosen't have necessary files. The server fails to
start with the following error

standard_init_linux.go:190: exec user process caused "no such file or directory"