### PR TITLE
Added active sessions to BQ extractor

### DIFF
--- a/bq-metrics-extractor/config/config.yaml
+++ b/bq-metrics-extractor/config/config.yaml
@@ -79,14 +79,14 @@ bqmetrics:
     help: Number of SIMs that has had an active data session today
     resultColumn: count
     sql: >
-      SELECT COUNT (DISTINCT user.msisdn) FROM `${DATASET_PROJECT}.ocs_gateway${DATASET_MODIFIER}.raw_activeusers`, UNNEST(users) as user
+      SELECT COUNT (DISTINCT user.msisdn) AS count FROM `${DATASET_PROJECT}.ocs_gateway${DATASET_MODIFIER}.raw_activeusers`, UNNEST(users) as user
       WHERE timestamp >= TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY)
   - type: gauge
     name: sims_who_was_active_yesterday
     help: Number of SIMs that has had an active data session yesterday
     resultColumn: count
     sql: >
-      SELECT COUNT (DISTINCT user.msisdn) FROM `${DATASET_PROJECT}.ocs_gateway${DATASET_MODIFIER}.raw_activeusers`, UNNEST(users) as user
+      SELECT COUNT (DISTINCT user.msisdn)  AS count FROM `${DATASET_PROJECT}.ocs_gateway${DATASET_MODIFIER}.raw_activeusers`, UNNEST(users) as user
       WHERE timestamp >= TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY), INTERVAL 1 DAY)
       AND timestamp < TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY)
   - type: gauge

--- a/bq-metrics-extractor/config/config.yaml
+++ b/bq-metrics-extractor/config/config.yaml
@@ -79,14 +79,14 @@ bqmetrics:
     help: Number of SIMs that has had an active data session today
     resultColumn: count
     sql: >
-      SELECT COUNT (DISTINCT user.msisdn) FROM `pantel-2decb.ocs_gateway.raw_activeusers`, UNNEST(users) as user
+      SELECT COUNT (DISTINCT user.msisdn) FROM `${DATASET_PROJECT}.ocs_gateway${DATASET_MODIFIER}.raw_activeusers`, UNNEST(users) as user
       WHERE timestamp >= TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY)
   - type: gauge
     name: sims_who_was_active_yesterday
     help: Number of SIMs that has had an active data session yesterday
     resultColumn: count
     sql: >
-      SELECT COUNT (DISTINCT user.msisdn) FROM `pantel-2decb.ocs_gateway.raw_activeusers`, UNNEST(users) as user
+      SELECT COUNT (DISTINCT user.msisdn) FROM `${DATASET_PROJECT}.ocs_gateway${DATASET_MODIFIER}.raw_activeusers`, UNNEST(users) as user
       WHERE timestamp >= TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY), INTERVAL 1 DAY)
       AND timestamp < TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY)
   - type: gauge

--- a/bq-metrics-extractor/config/config.yaml
+++ b/bq-metrics-extractor/config/config.yaml
@@ -75,6 +75,21 @@ bqmetrics:
       AND timestamp < TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY)
 
   - type: gauge
+    name: sims_who_have_been_active_today
+    help: Number of SIMs that has had an active data session today
+    resultColumn: count
+    sql: >
+      SELECT COUNT (DISTINCT user.msisdn) FROM `pantel-2decb.ocs_gateway.raw_activeusers`, UNNEST(users) as user
+      WHERE timestamp >= TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY)
+  - type: gauge
+    name: sims_who_was_active_yesterday
+    help: Number of SIMs that has had an active data session yesterday
+    resultColumn: count
+    sql: >
+      SELECT COUNT (DISTINCT user.msisdn) FROM `pantel-2decb.ocs_gateway.raw_activeusers`, UNNEST(users) as user
+      WHERE timestamp >= TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY), INTERVAL 1 DAY)
+      AND timestamp < TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY)
+  - type: gauge
     name: total_data_used_today
     help: Total data used today
     resultColumn: count


### PR DESCRIPTION
This will push the number of SIMs that has had an active data
session. This means any SIM that has tried to access the network
bot these that got an active session and those that did not have
enough credit to get online.