### PR TITLE
Updates 'active users' metrics extracted from BQ

### DIFF
--- a/bq-metrics-extractor/config/config.yaml
+++ b/bq-metrics-extractor/config/config.yaml
@@ -10,13 +10,31 @@ logging:
            level: severity
 
 bqmetrics:
-  - type: summary
-    name: active_users
-    help: Number of active users
+  - type: gauge
+    name: active_app_users_last24hours
+    help: Number of active application users last 24 hours
     resultColumn: count
     sql: >
         SELECT count(distinct user_pseudo_id) AS count FROM `${DATASET_PROJECT}.analytics_160712959.events_*`
-        WHERE event_name = "first_open"
+        WHERE (event_name = "session_start" OR event_name = "screen_view" OR event_name = "user_engagement")
+              AND timestamp_micros(event_timestamp) >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
+  - type: gauge
+    name: active_app_users_yesterday
+    help: Number of active application users yesterday
+    resultColumn: count
+    sql: >
+        SELECT count(distinct user_pseudo_id) AS count FROM `${DATASET_PROJECT}.analytics_160712959.events_*`
+        WHERE (event_name = "session_start" OR event_name = "screen_view" OR event_name = "user_engagement")
+              AND timestamp_micros(event_timestamp) >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
+              AND timestamp_micros(event_timestamp) < TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY)
+  - type: gauge
+    name: active_app_users_today
+    help: Number of active application users today
+    resultColumn: count
+    sql: >
+        SELECT count(distinct user_pseudo_id) AS count FROM `${DATASET_PROJECT}.analytics_160712959.events_*`
+        WHERE (event_name = "session_start" OR event_name = "screen_view" OR event_name = "user_engagement")
+              AND timestamp_micros(event_timestamp) >= TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY)
   - type: gauge
     name: sims_who_have_used_data
     help: Number of SIMs that has used data last 24 hours


### PR DESCRIPTION
Updated/new metrics:
  - active users last 24 hours
  - active users yesterday
  - active users today

The standard Firebase events:

  - session_start : user engages with the app
  - screen_view : user switches between screens in app
  - user_engagement : periodic events when app is in foreground

are used to determine whether an user is active or not. As all
of the events are subject to some limitations (see ref. below)
all of are included in the "active user" detection.

Ref.: https://support.google.com/firebase/answer/6317485