### PR TITLE
Remove keepalive timer on grpc channelbuilder

### DIFF
--- a/ocsgw/src/main/java/org/ostelco/ocsgw/datasource/protobuf/GrpcDataSource.java
+++ b/ocsgw/src/main/java/org/ostelco/ocsgw/datasource/protobuf/GrpcDataSource.java
@@ -161,8 +161,8 @@ public class GrpcDataSource implements DataSource {
 
             grpcChannel = channelBuilder
                     .keepAliveWithoutCalls(true)
-                    .keepAliveTimeout(1, TimeUnit.MINUTES)
-                    .keepAliveTime(5, TimeUnit.MINUTES)
+//                    .keepAliveTimeout(1, TimeUnit.MINUTES)
+//                    .keepAliveTime(20, TimeUnit.MINUTES)
                     .build();
 
             ocsServiceStub = OcsServiceGrpc.newStub(grpcChannel)

--- a/ocsgw/src/main/java/org/ostelco/ocsgw/metrics/OcsgwMetrics.java
+++ b/ocsgw/src/main/java/org/ostelco/ocsgw/metrics/OcsgwMetrics.java
@@ -31,7 +31,7 @@ public class OcsgwMetrics {
 
     private static final int KEEP_ALIVE_TIMEOUT_IN_MINUTES = 1;
 
-    private static final int KEEP_ALIVE_TIME_IN_MINUTES = 5;
+    private static final int KEEP_ALIVE_TIME_IN_MINUTES = 20;
 
     private OcsgwAnalyticsServiceGrpc.OcsgwAnalyticsServiceStub ocsgwAnalyticsServiceStub;
 
@@ -98,8 +98,8 @@ public class OcsgwMetrics {
 
             grpcChannel = channelBuilder
                     .keepAliveWithoutCalls(true)
-                    .keepAliveTimeout(KEEP_ALIVE_TIMEOUT_IN_MINUTES, TimeUnit.MINUTES)
-                    .keepAliveTime(KEEP_ALIVE_TIME_IN_MINUTES, TimeUnit.MINUTES)
+//                    .keepAliveTimeout(KEEP_ALIVE_TIMEOUT_IN_MINUTES, TimeUnit.MINUTES)
+//                    .keepAliveTime(KEEP_ALIVE_TIME_IN_MINUTES, TimeUnit.MINUTES)
                     .build();
 
             ocsgwAnalyticsServiceStub = OcsgwAnalyticsServiceGrpc.newStub(grpcChannel)


### PR DESCRIPTION
It seems that the best option is to keep these settings
on the default and have our own ping sent on the stream
instead.