### PR TITLE
Updates creation of 'customer' in Stripe with Prime 'id' and 'email'

### DIFF
--- a/acceptance-tests/src/main/kotlin/org/ostelco/at/common/StripePayment.kt
+++ b/acceptance-tests/src/main/kotlin/org/ostelco/at/common/StripePayment.kt
@@ -73,22 +73,18 @@ object StripePayment {
      * Obtains the Stripe 'customerId' directly from Stripe.
      */
     fun getStripeCustomerId(customerId: String) : String {
-
         // https://stripe.com/docs/api/java#create_card_token
         Stripe.apiKey = System.getenv("STRIPE_API_KEY")
 
         val customers = Customer.list(emptyMap()).data
-
-        val stripeEmail = "$customerId@ostelco.org"
-        return customers.first { it.email == stripeEmail }.id
+        return customers.first { it.id == customerId }.id
     }
 
     fun deleteCustomer(customerId: String) {
         // https://stripe.com/docs/api/java#create_card_token
         Stripe.apiKey = System.getenv("STRIPE_API_KEY")
         val customers = Customer.list(emptyMap()).data
-        val stripeEmail = "$customerId@ostelco.org"
-        customers.filter { it.email == stripeEmail }
+        customers.filter { it.id == customerId }
                 .forEach { it.delete() }
     }
 

--- a/customer-endpoint/src/main/kotlin/org/ostelco/prime/customer/endpoint/store/SubscriberDAOImpl.kt
+++ b/customer-endpoint/src/main/kotlin/org/ostelco/prime/customer/endpoint/store/SubscriberDAOImpl.kt
@@ -249,13 +249,13 @@ class SubscriberDAOImpl : SubscriberDAO {
     //
 
     override fun createSource(identity: Identity, sourceId: String): Either<ApiError, SourceInfo> {
-        return storage.getCustomerId(identity)
-                .mapLeft { error -> mapStorageErrorToApiError(error.message, ApiErrorCode.FAILED_TO_FETCH_CUSTOMER_ID, error) }
-                .flatMap { customerId ->
-                    paymentProcessor.getPaymentProfile(customerId = customerId)
+        return storage.getCustomer(identity)
+                .mapLeft { error -> mapStorageErrorToApiError(error.message, ApiErrorCode.FAILED_TO_FETCH_CUSTOMER, error) }
+                .flatMap { customer ->
+                    paymentProcessor.getPaymentProfile(customerId = customer.id)
                             .fold(
                                     {
-                                        paymentProcessor.createPaymentProfile(customerId = customerId)
+                                        paymentProcessor.createPaymentProfile(customerId = customer.id, email = customer.contactEmail)
                                                 .mapLeft { error -> mapPaymentErrorToApiError(error.description, ApiErrorCode.FAILED_TO_STORE_PAYMENT_SOURCE, error) }
                                     },
                                     { profileInfo -> Either.right(profileInfo) }
@@ -267,13 +267,13 @@ class SubscriberDAOImpl : SubscriberDAO {
     }
 
     override fun setDefaultSource(identity: Identity, sourceId: String): Either<ApiError, SourceInfo> {
-        return storage.getCustomerId(identity)
+        return storage.getCustomer(identity)
                 .mapLeft { error -> mapStorageErrorToApiError(error.message, ApiErrorCode.FAILED_TO_FETCH_CUSTOMER_ID, error) }
-                .flatMap { customerId ->
-                    paymentProcessor.getPaymentProfile(customerId = customerId)
+                .flatMap { customer ->
+                    paymentProcessor.getPaymentProfile(customerId = customer.id)
                             .fold(
                                     {
-                                        paymentProcessor.createPaymentProfile(customerId = customerId)
+                                        paymentProcessor.createPaymentProfile(customerId = customer.id, email = customer.contactEmail)
                                                 .mapLeft { error -> mapPaymentErrorToApiError(error.description, ApiErrorCode.FAILED_TO_SET_DEFAULT_PAYMENT_SOURCE, error) }
                                     },
                                     { profileInfo -> Either.right(profileInfo) }
@@ -286,13 +286,13 @@ class SubscriberDAOImpl : SubscriberDAO {
     }
 
     override fun listSources(identity: Identity): Either<ApiError, List<SourceDetailsInfo>> {
-        return storage.getCustomerId(identity)
+        return storage.getCustomer(identity)
                 .mapLeft { error -> mapStorageErrorToApiError(error.message, ApiErrorCode.FAILED_TO_FETCH_CUSTOMER_ID, error) }
-                .flatMap { customerId ->
-                    paymentProcessor.getPaymentProfile(customerId = customerId)
+                .flatMap { customer ->
+                    paymentProcessor.getPaymentProfile(customerId = customer.id)
                             .fold(
                                     {
-                                        paymentProcessor.createPaymentProfile(customerId = customerId)
+                                        paymentProcessor.createPaymentProfile(customerId = customer.id, email = customer.contactEmail)
                                                 .mapLeft { error -> mapPaymentErrorToApiError(error.description, ApiErrorCode.FAILED_TO_FETCH_PAYMENT_SOURCES_LIST, error) }
                                     },
                                     { profileInfo -> Either.right(profileInfo) }
@@ -318,10 +318,10 @@ class SubscriberDAOImpl : SubscriberDAO {
     }
 
     override fun getStripeEphemeralKey(identity: Identity, apiVersion: String): Either<ApiError, String> {
-        return storage.getCustomerId(identity)
+        return storage.getCustomer(identity)
                 .mapLeft { error -> mapStorageErrorToApiError(error.message, ApiErrorCode.FAILED_TO_FETCH_CUSTOMER_ID, error) }
-                .flatMap { customerId ->
-                    paymentProcessor.getStripeEphemeralKey(customerId = customerId, apiVersion = apiVersion)
+                .flatMap { customer ->
+                    paymentProcessor.getStripeEphemeralKey(customerId = customer.id, email = customer.contactEmail, apiVersion = apiVersion)
                             .mapLeft { error -> mapPaymentErrorToApiError(error.description, ApiErrorCode.FAILED_TO_GENERATE_STRIPE_EPHEMERAL_KEY, error) }
                 }
     }

--- a/neo4j-store/src/test/kotlin/org/ostelco/prime/storage/graph/Neo4jLoadTest.kt
+++ b/neo4j-store/src/test/kotlin/org/ostelco/prime/storage/graph/Neo4jLoadTest.kt
@@ -58,12 +58,12 @@ class Neo4jLoadTest {
 
         repeat(USERS) { user ->
             Neo4jStoreSingleton.addCustomer(
-                    identity = Identity(id = "test-$user@ostelco.org", type = "EMAIL", provider = "email"),
+                    identity = Identity(id = "test-$user", type = "EMAIL", provider = "email"),
                     customer = Customer(contactEmail = "test-$user@ostelco.org", nickname = NAME))
                     .mapLeft { fail(it.message) }
 
             Neo4jStoreSingleton.addSubscription(
-                    identity = Identity(id = "test-$user@ostelco.org", type = "EMAIL", provider = "email"),
+                    identity = Identity(id = "test-$user", type = "EMAIL", provider = "email"),
                     msisdn = "$user")
                     .mapLeft { fail(it.message) }
         }
@@ -109,7 +109,7 @@ class Neo4jLoadTest {
         val rate = COUNT * 1000.0 / diff
         println("Rate: %,.2f req/sec".format(rate))
 
-        Neo4jStoreSingleton.getBundles(identity = Identity(id = "test-0@ostelco.org", type = "EMAIL", provider = "email"))
+        Neo4jStoreSingleton.getBundles(identity = Identity(id = "test-0", type = "EMAIL", provider = "email"))
                 .fold(
                         { fail(it.message) },
                         {

--- a/payment-processor/src/integration-tests/kotlin/org/ostelco/prime/paymentprocessor/StripePaymentProcessorTest.kt
+++ b/payment-processor/src/integration-tests/kotlin/org/ostelco/prime/paymentprocessor/StripePaymentProcessorTest.kt
@@ -17,6 +17,7 @@ class StripePaymentProcessorTest {
 
     private val paymentProcessor = getResource<PaymentProcessor>()
     private val testCustomer = UUID.randomUUID().toString()
+    private val emailTestCustomer = "test@internet.org"
 
     private var stripeCustomerId = ""
 
@@ -55,7 +56,7 @@ class StripePaymentProcessorTest {
     }
 
     private fun addCustomer() {
-        val resultAdd = paymentProcessor.createPaymentProfile(testCustomer)
+        val resultAdd = paymentProcessor.createPaymentProfile(customerId = testCustomer, email = emailTestCustomer)
         assertEquals(true, resultAdd.isRight())
 
         stripeCustomerId = resultAdd.fold({ "" }, { it.id })

--- a/payment-processor/src/main/kotlin/org/ostelco/prime/paymentprocessor/StripePaymentProcessor.kt
+++ b/payment-processor/src/main/kotlin/org/ostelco/prime/paymentprocessor/StripePaymentProcessor.kt
@@ -1,6 +1,7 @@
 package org.ostelco.prime.paymentprocessor
 
 import arrow.core.Either
+import arrow.core.Try
 import arrow.core.flatMap
 import arrow.core.right
 import com.stripe.exception.ApiConnectionException
@@ -114,25 +115,29 @@ class StripePaymentProcessor : PaymentProcessor {
         return System.currentTimeMillis() / 1000L
     }
 
-    override fun createPaymentProfile(customerId: String): Either<PaymentError, ProfileInfo> =
+    override fun createPaymentProfile(customerId: String, email: String): Either<PaymentError, ProfileInfo> =
             either("Failed to create profile for user $customerId") {
                 val customerParams = mapOf(
-                        "email" to "$customerId@ostelco.org",
+                        "id" to customerId,
+                        "email" to email,
                         "metadata" to mapOf("customerId" to customerId))
                 ProfileInfo(Customer.create(customerParams).id)
             }
 
-    override fun getPaymentProfile(customerId: String): Either<PaymentError, ProfileInfo> {
-        val customerParams = mapOf(
-                "limit" to "1",
-                "email" to "$customerId@ostelco.org")
-        val customerList = Customer.list(customerParams)
-        return when {
-            customerList.data.isEmpty() -> Either.left(NotFoundError("Could not find a payment profile for user $customerId"))
-            customerList.data.size > 1 -> Either.left(NotFoundError("Multiple profiles for user $customerId found"))
-            else -> Either.right(ProfileInfo(customerList.data.first().id))
-        }
-    }
+    override fun getPaymentProfile(customerId: String): Either<PaymentError, ProfileInfo> =
+            Try {
+                Customer.retrieve(customerId)
+            }.fold(
+                    ifSuccess = { customer ->
+                        when {
+                            customer.deleted == true -> Either.left(NotFoundError("Payment profile for user $customerId was previously deleted"))
+                            else -> Either.right(ProfileInfo(customer.id))
+                        }
+                    },
+                    ifFailure = {
+                        Either.left(NotFoundError("Could not find a payment profile for user $customerId"))
+                    }
+            )
 
     override fun createPlan(productId: String, amount: Int, currency: String, interval: PaymentProcessor.Interval, intervalCount: Long): Either<PaymentError, PlanInfo> =
             either("Failed to create plan for product $productId amount $amount currency $currency interval ${interval.value}") {
@@ -288,10 +293,10 @@ class StripePaymentProcessor : PaymentProcessor {
                 SourceInfo(sourceId)
             }
 
-    override fun getStripeEphemeralKey(customerId: String, apiVersion: String): Either<PaymentError, String> =
+    override fun getStripeEphemeralKey(customerId: String, email: String, apiVersion: String): Either<PaymentError, String> =
             getPaymentProfile(customerId)
                     .fold(
-                            { createPaymentProfile(customerId) },
+                            { createPaymentProfile(customerId, email) },
                             { profileInfo -> profileInfo.right() }
                     ).flatMap { profileInfo ->
                         either("Failed to create stripe ephemeral key") {
@@ -338,4 +343,3 @@ class StripePaymentProcessor : PaymentProcessor {
         }
     }
 }
-

--- a/prime-modules/src/main/kotlin/org/ostelco/prime/paymentprocessor/PaymentProcessor.kt
+++ b/prime-modules/src/main/kotlin/org/ostelco/prime/paymentprocessor/PaymentProcessor.kt
@@ -27,9 +27,10 @@ interface PaymentProcessor {
 
     /**
      * @param customerId: Prime unique identifier for customer
+     * @param email: Contact email address
      * @return Stripe customerId if created
      */
-    fun createPaymentProfile(customerId: String): Either<PaymentError, ProfileInfo>
+    fun createPaymentProfile(customerId: String, email: String): Either<PaymentError, ProfileInfo>
 
     /**
      * @param stripeCustomerId Stripe customer id
@@ -135,5 +136,5 @@ interface PaymentProcessor {
      */
     fun removeSource(stripeCustomerId: String, sourceId: String): Either<PaymentError, SourceInfo>
 
-    fun getStripeEphemeralKey(customerId: String, apiVersion: String): Either<PaymentError, String>
+    fun getStripeEphemeralKey(customerId: String, email: String, apiVersion: String): Either<PaymentError, String>
 }


### PR DESCRIPTION
Previously a 'customer' in Stripe was created with 'email' set
to 'uuid@ostelco.org' and 'id' set to an id created by Stripe.
This update changes this such that the 'id' in Stripe now is set
to 'uuid' and 'email' to 'contactEmail'.