### PR TITLE
 Updated ocsgw tests

### DIFF
--- a/diameter-test/src/main/kotlin/org/ostelco/diameter/test/TestHelper.kt
+++ b/diameter-test/src/main/kotlin/org/ostelco/diameter/test/TestHelper.kt
@@ -49,8 +49,12 @@ object TestHelper {
             avp(Avp.MULTIPLE_SERVICES_INDICATOR, 1, pFlag = true)
 
             group(Avp.MULTIPLE_SERVICES_CREDIT_CONTROL) {
-                avp(Avp.RATING_GROUP, ratingGroup, pFlag = true)
-                avp(Avp.SERVICE_IDENTIFIER_CCA, serviceIdentifier, pFlag = true)
+                if (ratingGroup > 0) {
+                    avp(Avp.RATING_GROUP, ratingGroup, pFlag = true)
+                }
+                if (serviceIdentifier > 0) {
+                    avp(Avp.SERVICE_IDENTIFIER_CCA, serviceIdentifier, pFlag = true)
+                }
 
                 group(Avp.REQUESTED_SERVICE_UNIT) {
                     avp(Avp.CC_TOTAL_OCTETS, bucketSize, pFlag = true)
@@ -121,13 +125,20 @@ object TestHelper {
         }
     }
 
+    @JvmStatic
+    fun addUnknownApv(ccrAvps: AvpSet) {
+        set(ccrAvps) {
+            avp(950, "Unknown AVP", vendorId = 2011, asOctetString = true, pFlag = false, mFlag = false)
+        }
+    }
+
 
 
     @JvmStatic
-    fun createInitRequest(ccrAvps: AvpSet, msisdn: String, bucketSize: Long) {
+    fun createInitRequest(ccrAvps: AvpSet, msisdn: String, bucketSize: Long, ratingGroup: Int, serviceIdentifier: Int) {
         buildBasicRequest(ccrAvps, RequestType.INITIAL_REQUEST, requestNumber = 0)
         addUser(ccrAvps, msisdn = msisdn, imsi = IMSI)
-        addBucketRequest(ccrAvps, ratingGroup = 10, serviceIdentifier = 1, bucketSize = bucketSize)
+        addBucketRequest(ccrAvps, ratingGroup, serviceIdentifier, bucketSize = bucketSize)
         addServiceInformation(ccrAvps, apn = APN, sgsnMccMnc = SGSN_MCC_MNC)
     }
 
@@ -142,26 +153,26 @@ object TestHelper {
     }
 
     @JvmStatic
-    fun createUpdateRequest(ccrAvps: AvpSet, msisdn: String, bucketSize: Long, usedBucketSize: Long) {
+    fun createUpdateRequest(ccrAvps: AvpSet, msisdn: String, bucketSize: Long, usedBucketSize: Long, ratingGroup: Int, serviceIdentifier: Int) {
         buildBasicRequest(ccrAvps, RequestType.UPDATE_REQUEST, requestNumber = 1)
         addUser(ccrAvps, msisdn = msisdn, imsi = IMSI)
-        addBucketRequest(ccrAvps, ratingGroup = 10, serviceIdentifier = 1, bucketSize = bucketSize, usedBucketSize = usedBucketSize)
+        addBucketRequest(ccrAvps, ratingGroup, serviceIdentifier, bucketSize = bucketSize, usedBucketSize = usedBucketSize)
         addServiceInformation(ccrAvps, apn = APN, sgsnMccMnc = SGSN_MCC_MNC)
     }
 
     @JvmStatic
-    fun createUpdateRequestFinal(ccrAvps: AvpSet, msisdn: String, usedBucketSize: Long) {
+    fun createUpdateRequestFinal(ccrAvps: AvpSet, msisdn: String, usedBucketSize: Long, ratingGroup: Int, serviceIdentifier: Int) {
         buildBasicRequest(ccrAvps, RequestType.UPDATE_REQUEST, requestNumber = 1)
         addUser(ccrAvps, msisdn = msisdn, imsi = IMSI)
-        addFinalBucketRequest(ccrAvps, ratingGroup = 10, serviceIdentifier = 1, usedBucketSize = usedBucketSize)
+        addFinalBucketRequest(ccrAvps, ratingGroup, serviceIdentifier, usedBucketSize = usedBucketSize)
         addServiceInformation(ccrAvps, apn = APN, sgsnMccMnc = SGSN_MCC_MNC)
     }
 
     @JvmStatic
-    fun createTerminateRequest(ccrAvps: AvpSet, msisdn: String, bucketSize: Long) {
+    fun createTerminateRequest(ccrAvps: AvpSet, msisdn: String, bucketSize: Long, ratingGroup: Int, serviceIdentifier: Int) {
         buildBasicRequest(ccrAvps, RequestType.TERMINATION_REQUEST, requestNumber = 2)
         addUser(ccrAvps, msisdn = msisdn, imsi = IMSI)
-        addTerminateRequest(ccrAvps, ratingGroup = 10, serviceIdentifier = 1, bucketSize = bucketSize)
+        addTerminateRequest(ccrAvps, ratingGroup, serviceIdentifier, bucketSize = bucketSize)
         addServiceInformation(ccrAvps, apn = APN, sgsnMccMnc = SGSN_MCC_MNC)
     }
 

--- a/ocs-ktc/src/main/kotlin/org/ostelco/prime/ocs/core/OnlineCharging.kt
+++ b/ocs-ktc/src/main/kotlin/org/ostelco/prime/ocs/core/OnlineCharging.kt
@@ -135,6 +135,10 @@ object OnlineCharging : OcsAsyncRequestConsumer {
         // FixMe : Fetch list from somewhere ™
         // For now hardcoded to known combinations
 
+        if (arrayOf(600L).contains(ratingGroup)) {
+            return true
+        }
+
         if (arrayOf(1L, 400L).contains(serviceIdentifier)) {
             return true
         }

--- a/ocsgw/src/main/java/org/ostelco/ocsgw/converter/ProtobufToDiameterConverter.java
+++ b/ocsgw/src/main/java/org/ostelco/ocsgw/converter/ProtobufToDiameterConverter.java
@@ -72,7 +72,7 @@ public class ProtobufToDiameterConverter {
         return ResultCode.valueOf(resultCode.name());
     }
 
-    public static CreditControlRequestInfo convertRequestToGrpc(final CreditControlContext context, @Nullable final String topicId) {
+    public static CreditControlRequestInfo convertRequestToProtobuf(final CreditControlContext context, @Nullable final String topicId) {
 
         try {
             CreditControlRequestInfo.Builder builder = CreditControlRequestInfo

--- a/ocsgw/src/main/java/org/ostelco/ocsgw/datasource/protobuf/ProtobufDataSource.kt
+++ b/ocsgw/src/main/java/org/ostelco/ocsgw/datasource/protobuf/ProtobufDataSource.kt
@@ -38,7 +38,7 @@ class ProtobufDataSource {
         logger.info("[>>] creditControlRequest for {}", context.creditControlRequest.msisdn)
 
         // FixMe: We should handle conversion errors
-        val creditControlRequestInfo = ProtobufToDiameterConverter.convertRequestToGrpc(context, topicId)
+        val creditControlRequestInfo = ProtobufToDiameterConverter.convertRequestToProtobuf(context, topicId)
         if (creditControlRequestInfo != null) {
             ccrMap[context.sessionId] = context
             addToSessionMap(context)

--- a/ocsgw/src/test/java/org/ostelco/ocsgw/OcsApplicationTest.java
+++ b/ocsgw/src/test/java/org/ostelco/ocsgw/OcsApplicationTest.java
@@ -78,7 +78,7 @@ public class OcsApplicationTest {
                 session
         );
 
-        TestHelper.createInitRequest(request.getAvps(), MSISDN, 500000L);
+        TestHelper.createInitRequest(request.getAvps(), MSISDN, 500000L, 10, 1);
 
         client.sendNextRequest(request, session);
 
@@ -109,7 +109,7 @@ public class OcsApplicationTest {
                 session
         );
 
-        TestHelper.createUpdateRequest(request.getAvps(), MSISDN, 400000L, 500000L);
+        TestHelper.createUpdateRequest(request.getAvps(), MSISDN, 400000L, 500000L, 10, 1);
 
         client.sendNextRequest(request, session);
 
@@ -142,7 +142,7 @@ public class OcsApplicationTest {
                 session
         );
 
-        TestHelper.createTerminateRequest(request.getAvps(), MSISDN, 700000L);
+        TestHelper.createTerminateRequest(request.getAvps(), MSISDN, 700000L, 10, 1);
 
         client.sendNextRequest(request, session);
 
@@ -213,6 +213,41 @@ public class OcsApplicationTest {
     }
 
     @Test
+    @DisplayName("test AVP not in Diameter dictionary")
+    public void testUnknownAVP() {
+
+        Session session = client.createSession();
+        Request request = client.createRequest(
+                OCS_REALM,
+                OCS_HOST,
+                session
+        );
+
+        TestHelper.createInitRequest(request.getAvps(), MSISDN, 500000L, 10, 1);
+        TestHelper.addUnknownApv(request.getAvps());
+
+        client.sendNextRequest(request, session);
+
+        waitForAnswer();
+
+        try {
+            assertEquals(2001L, client.getResultCodeAvp().getInteger32());
+            AvpSet resultAvps = client.getResultAvps();
+            assertEquals(OCS_HOST, resultAvps.getAvp(Avp.ORIGIN_HOST).getUTF8String());
+            assertEquals(OCS_REALM, resultAvps.getAvp(Avp.ORIGIN_REALM).getUTF8String());
+            assertEquals(RequestType.INITIAL_REQUEST, resultAvps.getAvp(Avp.CC_REQUEST_TYPE).getInteger32());
+            Avp resultMSCC = resultAvps.getAvp(Avp.MULTIPLE_SERVICES_CREDIT_CONTROL);
+            assertEquals(2001L, resultMSCC.getGrouped().getAvp(Avp.RESULT_CODE).getInteger32());
+            assertEquals(1, resultMSCC.getGrouped().getAvp(Avp.SERVICE_IDENTIFIER_CCA).getUnsigned32());
+            assertEquals(10, resultMSCC.getGrouped().getAvp(Avp.RATING_GROUP).getUnsigned32());
+            Avp granted = resultMSCC.getGrouped().getAvp(Avp.GRANTED_SERVICE_UNIT);
+            assertEquals(500000L, granted.getGrouped().getAvp(Avp.CC_TOTAL_OCTETS).getUnsigned64());
+        } catch (AvpDataException e) {
+            LOG.error("Failed to get Result-Code", e);
+        }
+    }
+
+    @Test
     public void testReAuthRequest() {
         Session session = client.createSession();
         simpleCreditControlRequestInit(session);
@@ -247,7 +282,7 @@ public class OcsApplicationTest {
         );
 
         AvpSet ccrAvps = request.getAvps();
-        TestHelper.createInitRequest(ccrAvps, MSISDN, 500000L);
+        TestHelper.createInitRequest(ccrAvps, MSISDN, 500000L, 10, 1);
 
         AvpSet serviceInformation = ccrAvps.addGroupedAvp(Avp.SERVICE_INFORMATION, VENDOR_ID_3GPP, true, false);
         AvpSet psInformation = serviceInformation.addGroupedAvp(Avp.PS_INFORMATION, VENDOR_ID_3GPP, true, false);

--- a/ocsgw/src/test/java/org/ostelco/ocsgw/OcsHATest.java
+++ b/ocsgw/src/test/java/org/ostelco/ocsgw/OcsHATest.java
@@ -154,7 +154,7 @@ public class OcsHATest {
                 session
         );
 
-        TestHelper.createInitRequest(request.getAvps(), MSISDN, 500000L);
+        TestHelper.createInitRequest(request.getAvps(), MSISDN, 500000L, 1, 10);
 
         testPGW.sendNextRequest(request, session);
 
@@ -226,7 +226,7 @@ public class OcsHATest {
                 session
         );
 
-        TestHelper.createUpdateRequest(request.getAvps(), MSISDN, 400000L, 500000L);
+        TestHelper.createUpdateRequest(request.getAvps(), MSISDN, 400000L, 500000L, 1, 10);
 
         testPGW.sendNextRequest(request, session);
 
@@ -278,7 +278,7 @@ public class OcsHATest {
                 session
         );
 
-        TestHelper.createTerminateRequest(request.getAvps(), MSISDN, 700000L);
+        TestHelper.createTerminateRequest(request.getAvps(), MSISDN, 700000L, 1, 10);
 
         testPGW.sendNextRequest(request, session);
 


### PR DESCRIPTION
These new test will check that we handle AVPs that are not set
in the Diameter dictionary. It will also check that we handle
CCR without servide-Identifier set in the MSCC.