### PR TITLE
Do not set input or output octets in granted service units

### DIFF
--- a/diameter-stack/src/main/kotlin/org/ostelco/diameter/CreditControlContext.kt
+++ b/diameter-stack/src/main/kotlin/org/ostelco/diameter/CreditControlContext.kt
@@ -89,8 +89,8 @@ class CreditControlContext(
 
                 if (mscc.granted.total > -1) {
                     val gsuAvp = answerMSCC.addGroupedAvp(Avp.GRANTED_SERVICE_UNIT, true, false)
-                    gsuAvp.addAvp(Avp.CC_INPUT_OCTETS, 0L, true, false)
-                    gsuAvp.addAvp(Avp.CC_OUTPUT_OCTETS, 0L, true, false)
+                    //gsuAvp.addAvp(Avp.CC_INPUT_OCTETS, 0L, true, false)
+                    //gsuAvp.addAvp(Avp.CC_OUTPUT_OCTETS, 0L, true, false)
                     gsuAvp.addAvp(Avp.CC_TOTAL_OCTETS, mscc.granted.total, true, false)
                 }
             }


### PR DESCRIPTION
It seems that setting input and output octets to zero will
cause more harm then good. The client is supposed to ignore
these if total is set but some implementation miss that.
So then it is better to not set this at all.