### PR TITLE
Update direct deploy and canary setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,7 +269,7 @@ jobs:
             /authenticate.bash
             helm repo add ostelco https://storage.googleapis.com/pi-ostelco-helm-charts-repo/
             helm repo update
-            helm upgrade prime ostelco/prime --version 0.6.3 --install \
+            helm upgrade prime ostelco/prime --version 1.0.0 --install \
              --namespace dev \
              -f .circleci/prime-dev-values.yaml \
              --set prime.tag=$TAG 
@@ -330,9 +330,9 @@ jobs:
             /authenticate.bash
             helm repo add ostelco https://storage.googleapis.com/pi-ostelco-helm-charts-repo/
             helm repo update
-            helm upgrade prime ostelco/prime --version 0.6.3 --install \
+            helm upgrade prime ostelco/prime --version 1.0.0 --install \
              --namespace prod \
-             -f .circleci/prime-prod-values.yaml \
+             -f .circleci/prime-canary-values.yaml \
              --set prime.tag=$TAG
 
 #             --set-string canary.tag=${CIRCLE_SHA1:0:9} \
@@ -343,6 +343,37 @@ jobs:
           when: on_fail
           command: .circleci/notify-slack.sh on-PR-merge-to-master false
 
+  deploy-stable-prod:
+    docker:
+      - image: praqma/gcloud-kubectl-helm:v2.11.0
+        environment:
+          PROJECT: pi-ostelco-prod
+          CLUSTER: pi-prod
+          ZONE: europe-west1-c
+          SERVICE_ACCOUNT: terraform-manage-cluster-from@pi-ostelco-prod.iam.gserviceaccount.com
+
+    steps:
+      - attach_workspace:
+          # Must be absolute path or relative path from working_directory
+          at: ~/project
+      - run:
+          name: deploy stable prod prime to the prod cluster
+          command: |
+            PRIME_VERSION=$(cat prime_version)
+            TAG=$PRIME_VERSION-${CIRCLE_SHA1:0:9}
+            export GOOGLE_CREDENTIALS=${PI_PROD_CLUSTER_CREDENTIALS}
+            /authenticate.bash
+            helm repo add ostelco https://storage.googleapis.com/pi-ostelco-helm-charts-repo/
+            helm repo update
+            helm upgrade prime ostelco/prime --version 1.0.0 --install \
+             --namespace prod \
+             -f .circleci/prime-prod-values.yaml \
+             --set prime.tag=$TAG
+
+      - run:
+          name: notify slack on failure
+          when: on_fail
+          command: .circleci/notify-slack.sh on-PR-merge-to-master false      
 workflows:
   version: 2
   on-feature-branch-commit:
@@ -371,13 +402,20 @@ workflows:
       - deploy-to-dev:
           requires:
             - update-dev-endpoints
-      - approve-prod-deploy:
+      - approve-prod-canary-deploy:
           type: approval
           requires:
             - deploy-to-dev
       - update-prod-endpoints:
           requires:
-            - approve-prod-deploy
+            - approve-prod-canary-deploy
       - deploy-canary:
           requires:
             - update-prod-endpoints
+      - approve-prod-stable-deploy:
+          type: approval
+          requires:
+            - deploy-canary 
+      - deploy-stable-prod:
+          requires:
+            - approve-prod-stable-deploy           

--- a/.circleci/prime-canary-values.yaml
+++ b/.circleci/prime-canary-values.yaml
@@ -1,16 +1,16 @@
-# DEV values for prime.
+# PROD-CANARY values for prime.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
 replicaCount: 3
 
 dnsPrefix: ""
-dnsSuffix: ".dev.oya.world"
+dnsSuffix: ".oya.world"
 
 podAutoscaling:
   enabled: true
   minReplicas: 3
-  maxReplicas: 5
+  maxReplicas: 8
   metrics:
     - type: Resource
       resource:
@@ -26,22 +26,22 @@ cronjobs:
     enabled: true
     image: eu.gcr.io/pi-ostelco-dev/bq-metrics-extractor
     tag: "1.3.212.1.0-2d41d62b-dev"  
-    dataset_project: pi-ostelco-dev
+    dataset_project: pi-ostelco-prod
   shredder:
     enabled: true
     image: eu.gcr.io/pi-ostelco-dev/scaninfo-shredder
     tag: "1.0.0-6052932a-dev"
-    dataset_project: pi-ostelco-dev
-    dev: true
+    dataset_project: pi-ostelco-prod
+    dev: false
 
 prime:
   image: eu.gcr.io/pi-ostelco-dev/prime
-  tag: "" # tag is passed from CI
+  tag: "" # it will be set from CI
   pullPolicy: Always
-  configDataBucket: "gs://pi-ostelco-dev-prime-files/dev"
+  configDataBucket: "gs://pi-ostelco-prod-prime-files/prod"
 
   env:
-    FIREBASE_ROOT_PATH: dev
+    FIREBASE_ROOT_PATH: v2
     NEO4J_HOST: neo4j-neo4j.neo4j.svc.cluster.local
     SLACK_CHANNEL: prime-alerts
     DATA_TRAFFIC_TOPIC: data-traffic
@@ -51,18 +51,18 @@ prime:
     STRIPE_EVENT_STORE_SUBSCRIPTION: stripe-event-store-sub
     STRIPE_EVENT_REPORT_SUBSCRIPTION: stripe-event-report-sub
     STRIPE_EVENT_RECURRING_PAYMENT_SUBSCRIPTION: stripe-event-recurring-payment-sub
-    GCP_PROJECT_ID: pi-ostelco-dev
+    GCP_PROJECT_ID: pi-ostelco-prod
     ACTIVATE_TOPIC_ID: ocs-activate
     CCR_SUBSCRIPTION_ID: ocs-ccr-sub
     GOOGLE_APPLICATION_CREDENTIALS: /secret/prime-service-account.json
-    MY_INFO_API_URI: https://myinfosgstg.api.gov.sg/test/v2
-    MY_INFO_API_REALM: dev
-    MY_INFO_REDIRECT_URI: https://dl-dev.oya.world/links/myinfo
+    MY_INFO_API_URI: https://myinfosg.api.gov.sg/v2
+    MY_INFO_API_REALM: prod
+    MY_INFO_REDIRECT_URI: https://dl.oya.world/links/myinfo
 
   secretVolumes:
     - secretName: "prime-sa-key"
       containerMountPath: "/secret"
-    - secretName: "simmgr-test-secrets"
+    - secretName: "simmgr-secrets"
       containerMountPath: "/certs"
       secretKey: idemiaClientCert
       secretPath: idemia-client-cert.jks
@@ -104,31 +104,31 @@ prime:
       secretName: myinfo-secrets
       secretKey: clientPrivateKey
     - name: DB_USER
-      secretName: simmgr-test-secrets
+      secretName: simmgr-secrets
       secretKey: dbUser
     - name: DB_PASSWORD
-      secretName: simmgr-test-secrets
+      secretName: simmgr-secrets
       secretKey: dbPassword
     - name: DB_URL
-      secretName: simmgr-test-secrets
+      secretName: simmgr-secrets
       secretKey: dbUrl
     - name: WG2_USER
-      secretName: simmgr-test-secrets
+      secretName: simmgr-secrets
       secretKey: wg2User
     - name: WG2_API_KEY
-      secretName: simmgr-test-secrets
+      secretName: simmgr-secrets
       secretKey: wg2ApiKey
     - name: WG2_ENDPOINT
-      secretName: simmgr-test-secrets
+      secretName: simmgr-secrets
       secretKey: wg2Endpoint
     - name: ES2PLUS_ENDPOINT
-      secretName: simmgr-test-secrets
+      secretName: simmgr-secrets
       secretKey: es2plusEndpoint
     - name: ES9PLUS_ENDPOINT
-      secretName: simmgr-test-secrets
+      secretName: simmgr-secrets
       secretKey: es9plusEndpoint
     - name: FUNCTION_REQUESTER_IDENTIFIER
-      secretName: simmgr-test-secrets
+      secretName: simmgr-secrets
       secretKey: functionRequesterIdentifier
     - name: MANDRILL_API_KEY
       secretName: mandrill-secrets
@@ -140,19 +140,27 @@ prime:
     - 8082 
     - 8083 
   resources: 
+#    limits:
+#      cpu: 200m
+#      memory: 400Mi
     requests:
       cpu: 300m
       memory: 512Mi
   livenessProbe: {}
+    # path: /
+    # port: 8081
   readinessProbe: {}
+    # path: /
+    # port: 8081  
   annotations: 
     prometheus.io/scrape: 'true'
     prometheus.io/path: '/prometheus-metrics'
     prometheus.io/port: '8081'  
 
+
 cloudsqlProxy:
   enabled: true
-  instanceConnectionName: "pi-ostelco-dev:europe-west1:sim-manager"
+  instanceConnectionName: "pi-ostelco-prod:europe-west1:sim-manager"
   secretName: "prime-sa-key"
   secretKey: "prime-service-account.json"
 
@@ -164,45 +172,45 @@ esp:
 ocsEsp: 
   enabled: true
   env: {}
-  endpointAddress: ocs.dev.oya.world
+  endpointAddress: ocs.oya.world
   ports:
     http2_port: 9000
     ssl_port: 8443
   secretVolumes:
-    - secretName: dev-oya-tls
+    - secretName: prod-oya-tls
       containerMountPath: /etc/nginx/ssl
       type: ssl
 
 apiEsp: 
   enabled: true
   env: {}
-  endpointAddress: api.dev.oya.world
+  endpointAddress: api.oya.world
   ports:
     http2_port: 9002
 
 metricsEsp:
   enabled: true
   env: {}
-  endpointAddress: metrics.dev.oya.world
+  endpointAddress: metrics.oya.world
   ports:
     http2_port: 9004
     ssl_port: 9443
   secretVolumes:
-    - secretName: dev-oya-tls
+    - secretName: prod-oya-tls
       containerMountPath: /etc/nginx/ssl
       type: ssl
 
 alvinApiEsp:
   enabled: true
   env: {}
-  endpointAddress: alvin-api.dev.oya.world
+  endpointAddress: alvin-api.oya.world
   ports:
     http_port: 9008
 
 houstonApiEsp:
   enabled: true
   env: {}
-  endpointAddress: houston-api.dev.oya.world
+  endpointAddress: houston-api.oya.world
   ports:
     http_port: 9006
 
@@ -213,9 +221,7 @@ services:
     port: 443
     targetPort: 8443
     portName: grpc
-    # host: ocs # the host name is formulated from concatenating: dnsPrefix, this host, and dnsSuffix
-    # grpcOrHttp2: true
-
+    
   api:
     name: api
     type: ClusterIP
@@ -226,17 +232,16 @@ services:
     grpcOrHttp2: true
     ambassadorMappingOptions:
       timeout_ms: 600000
-    canary: {}  
-
+    canary: 
+      headers:
+        x-mode: canary
+ 
   metrics:
     name: metrics
     type: LoadBalancer
     port: 443
     targetPort: 9443
     portName: grpc
-    # loadBalancerIP: x.y.z.n
-    # host: metrics # the host name is formulated from concatenating: dnsPrefix, this host, and dnsSuffix
-    # grpcOrHttp2: true
 
   prime-houston-api:
     name: houston-api
@@ -247,8 +252,10 @@ services:
     host: houston-api # the host name is formulated from concatenating: dnsPrefix, this host, and dnsSuffix
     ambassadorMappingOptions:
       timeout_ms: 600000
-    canary: {}
-
+    canary: 
+      headers:
+        x-mode: canary
+ 
   prime-alvin-api:
     name: alvin-api
     type: ClusterIP
@@ -258,7 +265,9 @@ services:
     host: alvin-api # the host name is formulated from concatenating: dnsPrefix, this host, and dnsSuffix
     ambassadorMappingOptions:
       timeout_ms: 600000
-    canary: {} 
+    canary: 
+      headers:
+        x-mode: canary
 
   dwadmin-service:
     name: dwadmin-service
@@ -266,7 +275,7 @@ services:
     port: 8081
     targetPort: 8081
     portName: http
-    
+
   smdpplus:
     name: smdpplus
     type: ClusterIP
@@ -275,16 +284,18 @@ services:
     portName: http
     host: smdpplus
     clientCert: true
-    caCert: smdp-cacert.dev # secretname.namespace
-    canary: {}
+    caCert: smdp-cacert.prod # secretname.namespace
+    canary: 
+      headers:
+        x-mode: canary
 
 certs:
   enabled: true
   dnsProvider: dev-clouddns
-  issuer: letsencrypt-production
-  tlsSecretName: dev-oya-tls
+  issuer: letsencrypt-production # or letsencrypt-staging
+  tlsSecretName: prod-oya-tls
   hosts:
-    - '*.dev.oya.world'
+    - '*.oya.world'
 
 disruptionBudget: 
   enabled: false

--- a/.circleci/prime-canary-values.yaml
+++ b/.circleci/prime-canary-values.yaml
@@ -21,12 +21,7 @@ podAutoscaling:
         name: memory
         targetAverageUtilization: 70
 
-cronjobs: 
-  extractor: 
-    enabled: true
-    image: eu.gcr.io/pi-ostelco-dev/bq-metrics-extractor
-    tag: "1.3.212.1.0-2d41d62b-dev"  
-    dataset_project: pi-ostelco-prod
+cronjobs:
   shredder:
     enabled: true
     image: eu.gcr.io/pi-ostelco-dev/scaninfo-shredder
@@ -157,7 +152,6 @@ prime:
     prometheus.io/path: '/prometheus-metrics'
     prometheus.io/port: '8081'  
 
-
 cloudsqlProxy:
   enabled: true
   instanceConnectionName: "pi-ostelco-prod:europe-west1:sim-manager"
@@ -221,7 +215,7 @@ services:
     port: 443
     targetPort: 8443
     portName: grpc
-    
+
   api:
     name: api
     type: ClusterIP
@@ -232,10 +226,10 @@ services:
     grpcOrHttp2: true
     ambassadorMappingOptions:
       timeout_ms: 600000
-    canary: 
+    canary:
       headers:
         x-mode: canary
- 
+
   metrics:
     name: metrics
     type: LoadBalancer
@@ -252,10 +246,10 @@ services:
     host: houston-api # the host name is formulated from concatenating: dnsPrefix, this host, and dnsSuffix
     ambassadorMappingOptions:
       timeout_ms: 600000
-    canary: 
+    canary:
       headers:
         x-mode: canary
- 
+
   prime-alvin-api:
     name: alvin-api
     type: ClusterIP
@@ -285,7 +279,7 @@ services:
     host: smdpplus
     clientCert: true
     caCert: smdp-cacert.prod # secretname.namespace
-    canary: 
+    canary:
       headers:
         x-mode: canary
 

--- a/.circleci/prime-dev-values.yaml
+++ b/.circleci/prime-dev-values.yaml
@@ -22,11 +22,6 @@ podAutoscaling:
         targetAverageUtilization: 70
 
 cronjobs: 
-  extractor: 
-    enabled: true
-    image: eu.gcr.io/pi-ostelco-dev/bq-metrics-extractor
-    tag: "1.3.212.1.0-2d41d62b-dev"  
-    dataset_project: pi-ostelco-dev
   shredder:
     enabled: true
     image: eu.gcr.io/pi-ostelco-dev/scaninfo-shredder
@@ -36,7 +31,7 @@ cronjobs:
 
 prime:
   image: eu.gcr.io/pi-ostelco-dev/prime
-  tag: "" # tag is passed from CI
+  tag: "" # it will be set from CI
   pullPolicy: Always
   configDataBucket: "gs://pi-ostelco-dev-prime-files/dev"
 
@@ -213,8 +208,6 @@ services:
     port: 443
     targetPort: 8443
     portName: grpc
-    # host: ocs # the host name is formulated from concatenating: dnsPrefix, this host, and dnsSuffix
-    # grpcOrHttp2: true
 
   api:
     name: api
@@ -226,7 +219,7 @@ services:
     grpcOrHttp2: true
     ambassadorMappingOptions:
       timeout_ms: 600000
-    canary: {}  
+    canary: {}
 
   metrics:
     name: metrics
@@ -234,9 +227,6 @@ services:
     port: 443
     targetPort: 9443
     portName: grpc
-    # loadBalancerIP: x.y.z.n
-    # host: metrics # the host name is formulated from concatenating: dnsPrefix, this host, and dnsSuffix
-    # grpcOrHttp2: true
 
   prime-houston-api:
     name: houston-api
@@ -258,7 +248,7 @@ services:
     host: alvin-api # the host name is formulated from concatenating: dnsPrefix, this host, and dnsSuffix
     ambassadorMappingOptions:
       timeout_ms: 600000
-    canary: {} 
+    canary: {}
 
   dwadmin-service:
     name: dwadmin-service
@@ -266,7 +256,7 @@ services:
     port: 8081
     targetPort: 8081
     portName: http
-    
+
   smdpplus:
     name: smdpplus
     type: ClusterIP

--- a/.circleci/prime-prod-values.yaml
+++ b/.circleci/prime-prod-values.yaml
@@ -21,12 +21,7 @@ podAutoscaling:
         name: memory
         targetAverageUtilization: 70
 
-cronjobs: 
-  extractor: 
-    enabled: true
-    image: eu.gcr.io/pi-ostelco-dev/bq-metrics-extractor
-    tag: "1.3.212.1.0-2d41d62b-dev"  
-    dataset_project: pi-ostelco-prod
+cronjobs:
   shredder:
     enabled: true
     image: eu.gcr.io/pi-ostelco-dev/scaninfo-shredder
@@ -157,7 +152,6 @@ prime:
     prometheus.io/path: '/prometheus-metrics'
     prometheus.io/port: '8081'  
 
-
 cloudsqlProxy:
   enabled: true
   instanceConnectionName: "pi-ostelco-prod:europe-west1:sim-manager"
@@ -221,7 +215,7 @@ services:
     port: 443
     targetPort: 8443
     portName: grpc
-    
+
   api:
     name: api
     type: ClusterIP
@@ -233,7 +227,7 @@ services:
     ambassadorMappingOptions:
       timeout_ms: 600000
     canary: {}
- 
+
   metrics:
     name: metrics
     type: LoadBalancer
@@ -251,7 +245,7 @@ services:
     ambassadorMappingOptions:
       timeout_ms: 600000
     canary: {}
- 
+
   prime-alvin-api:
     name: alvin-api
     type: ClusterIP

--- a/.circleci/prime-prod-values.yaml
+++ b/.circleci/prime-prod-values.yaml
@@ -2,16 +2,24 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 2
+replicaCount: 3
 
 dnsPrefix: ""
 dnsSuffix: ".oya.world"
 
 podAutoscaling:
   enabled: true
-  minReplicas: 1
-  maxReplicas: 6
-  targetCPUUtilizationPercentage: 70
+  minReplicas: 3
+  maxReplicas: 8
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: 80
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: 70
 
 cronjobs: 
   extractor: 
@@ -28,7 +36,7 @@ cronjobs:
 
 prime:
   image: eu.gcr.io/pi-ostelco-dev/prime
-  tag: 634bac88 # stable tag
+  tag: "" # it will be set from CI
   pullPolicy: Always
   configDataBucket: "gs://pi-ostelco-prod-prime-files/prod"
 
@@ -136,8 +144,8 @@ prime:
 #      cpu: 200m
 #      memory: 400Mi
     requests:
-      cpu: 100m
-      memory: 300Mi
+      cpu: 300m
+      memory: 512Mi
   livenessProbe: {}
     # path: /
     # port: 8081
@@ -149,12 +157,6 @@ prime:
     prometheus.io/path: '/prometheus-metrics'
     prometheus.io/port: '8081'  
 
-
-canary: {}
-  # weight: 25
-  # headers: # only route requests with these headers to the canary service
-  #   x-mode: canary
-  # tag: ""
 
 cloudsqlProxy:
   enabled: true
@@ -230,6 +232,8 @@ services:
     grpcOrHttp2: true
     ambassadorMappingOptions:
       timeout_ms: 600000
+    canary: {}
+ 
   metrics:
     name: metrics
     type: LoadBalancer
@@ -246,6 +250,8 @@ services:
     host: houston-api # the host name is formulated from concatenating: dnsPrefix, this host, and dnsSuffix
     ambassadorMappingOptions:
       timeout_ms: 600000
+    canary: {}
+ 
   prime-alvin-api:
     name: alvin-api
     type: ClusterIP
@@ -255,12 +261,15 @@ services:
     host: alvin-api # the host name is formulated from concatenating: dnsPrefix, this host, and dnsSuffix
     ambassadorMappingOptions:
       timeout_ms: 600000
+    canary: {}
+
   dwadmin-service:
     name: dwadmin-service
     type: ClusterIP
     port: 8081
     targetPort: 8081
     portName: http
+
   smdpplus:
     name: smdpplus
     type: ClusterIP
@@ -270,6 +279,7 @@ services:
     host: smdpplus
     clientCert: true
     caCert: smdp-cacert.prod # secretname.namespace
+    canary: {}
 
 certs:
   enabled: true
@@ -283,7 +293,8 @@ disruptionBudget:
   enabled: false
   minAvailable: 1
 
-nodeSelector: {}
+nodeSelector: 
+  target: prime
 
 tolerations: []
 

--- a/prime/infra/README.md
+++ b/prime/infra/README.md
@@ -119,49 +119,9 @@ To avoid pipeline waiting time, you can take a short cut and deploy your feature
 
 **Steps:**
 
-1. Build the prime docker image from your feature branch and tag it with your custom tag (e.g. eu.gcr.io/pi-ostelco-dev/prime:feature-xyz)
+Run the [prime-direct deploy script](../script/helm-deploy-dev-direct.sh)
 
-2. Push the built image into the docker registry. 
-```bash
-# auth is needed since the docker registry is private
-$ gcloud auth login
-$ docker push eu.gcr.io/pi-ostelco-dev/prime:feature-xyz
-```
-
-3. [Install helm](https://helm.sh/docs/using_helm/#install-helm)
-
-4. Make your own copy of the helm values file.
-
-Copy the [prime-direct helm values file](prime-direct-values.yaml) and edit the DNS prefix in the `dnsPrefix` section with unique custom prefix (e.g. `feature-xyz-`). Make sure you have a dash at the end of your prefix.
-
-5. run the following helm commands:
-
-> Note: the helm release name must be unique. A good example might be feature name or developer name.
-
-> Note: you can change the helm chart version below to a specific version of the prime helm chart. 
-
-```bash 
-# the first command is only needed once
-$ helm repo add ostelco https://storage.googleapis.com/pi-ostelco-helm-charts-repo/
-$ helm repo update
-# if your kube context is not configured to point to the dev cluster, then configure it 
-$ kubectl config use-context gke_pi-ostelco-dev_europe-west1-c_pi-dev
-$ RELEASE_NAME=<some-unique-name>
-$ helm upgrade ${RELEASE_NAME} ostelco/prime --version 0.6.3 --install -f <path-to-your-custom-values-file> --set prime.tag=feature-xyz
-```
-you can then watch for your pods being created with this command:
-
-```bash 
-$ kubectl get pods -n dev -l release=${RELEASE_NAME} -w
-```
-
-Once your pods are in the `Running` state, you can test the APIs of your custom deployment on: feature-xyz-prime-api-name.test.oya.world (e.g. https://feature-xyz-api.test.oya.world)
-
-To delete your custom deployment:
-
-```bash
-$ helm delete --purge ${RELEASE_NAME}
-```
+-----
 
 ### Secrets
 

--- a/prime/infra/prime-direct-values.yaml
+++ b/prime/infra/prime-direct-values.yaml
@@ -2,16 +2,24 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 3
 
-dnsPrefix: "prime-direct-"
-dnsSuffix: ".test.oya.world"
+dnsPrefix: ""
+dnsSuffix: ".dev.oya.world"
 
 podAutoscaling:
   enabled: false
-  #minReplicas: 1
-  #maxReplicas: 5
-  #targetCPUUtilizationPercentage: 70
+  # minReplicas: 1
+  # maxReplicas: 5
+  # metrics:
+  #   - type: Resource
+  #     resource:
+  #       name: cpu
+  #       targetAverageUtilization: 80
+  #   - type: Resource
+  #     resource:
+  #       name: memory
+  #       targetAverageUtilization: 70
 
 cronjobs: 
   extractor: 
@@ -133,8 +141,8 @@ prime:
     - 8083 
   resources: 
     requests:
-      cpu: 100m
-      memory: 300Mi  
+      cpu: 300m
+      memory: 512Mi  
   livenessProbe: {}
   readinessProbe: {}
   annotations: 
@@ -142,12 +150,6 @@ prime:
     prometheus.io/path: '/prometheus-metrics'
     prometheus.io/port: '8081'  
 
-
-canary: {}
-  # weight: 25
-  # headers: # only route requests with these headers to the canary service
-  #   x-mode: canary
-  # tag: e449ed672
 
 cloudsqlProxy:
   enabled: true
@@ -214,6 +216,7 @@ services:
     portName: grpc
     # host: ocs # the host name is formulated from concatenating: dnsPrefix, this host, and dnsSuffix
     # grpcOrHttp2: true
+
   api:
     name: api
     type: ClusterIP
@@ -224,6 +227,11 @@ services:
     grpcOrHttp2: true
     ambassadorMappingOptions:
       timeout_ms: 600000
+    canary:
+      headers:
+        x-mode: prime-direct
+      # weight: 50   
+
   metrics:
     name: metrics
     type: LoadBalancer
@@ -233,6 +241,7 @@ services:
     # loadBalancerIP: x.y.z.n
     # host: metrics # the host name is formulated from concatenating: dnsPrefix, this host, and dnsSuffix
     # grpcOrHttp2: true
+
   prime-houston-api:
     name: houston-api
     type: ClusterIP
@@ -240,6 +249,13 @@ services:
     targetPort: 9006
     portName: http
     host: houston-api # the host name is formulated from concatenating: dnsPrefix, this host, and dnsSuffix
+    ambassadorMappingOptions:
+      timeout_ms: 600000
+    canary:
+      headers:
+        x-mode: prime-direct
+      # weight: 50   
+
   prime-alvin-api:
     name: alvin-api
     type: ClusterIP
@@ -247,12 +263,20 @@ services:
     targetPort: 9008
     portName: http
     host: alvin-api # the host name is formulated from concatenating: dnsPrefix, this host, and dnsSuffix
+    ambassadorMappingOptions:
+      timeout_ms: 600000
+    canary:
+      headers:
+        x-mode: prime-direct
+      # weight: 50   
+  
   dwadmin-service:
     name: dwadmin-service
     type: ClusterIP
     port: 8081
     targetPort: 8081
     portName: http
+
   smdpplus:
     name: smdpplus
     type: ClusterIP
@@ -262,20 +286,25 @@ services:
     host: smdpplus
     clientCert: true
     caCert: smdp-cacert.dev # secretname.namespace
+    canary:
+      headers:
+        x-mode: prime-direct
+      # weight: 50   
 
 certs:
   enabled: true
   dnsProvider: dev-clouddns
   issuer: letsencrypt-production 
-  tlsSecretName: test-oya-tls
+  tlsSecretName: dev-oya-tls
   hosts:
-    - '*.test.oya.world'
+    - '*.dev.oya.world'
 
 disruptionBudget: 
   enabled: false
   minAvailable: 1
 
-nodeSelector: {}
+nodeSelector: 
+  target: prime
 
 tolerations: []
 

--- a/prime/infra/prime-direct-values.yaml
+++ b/prime/infra/prime-direct-values.yaml
@@ -36,12 +36,12 @@ cronjobs:
 
 prime:
   image: eu.gcr.io/pi-ostelco-dev/prime
-  tag: 63114190f
+  tag: "" # it will be set from CI
   pullPolicy: Always
   configDataBucket: "gs://pi-ostelco-dev-prime-files/dev"
 
   env:
-    FIREBASE_ROOT_PATH: direct
+    FIREBASE_ROOT_PATH: dev
     NEO4J_HOST: neo4j-neo4j.neo4j.svc.cluster.local
     SLACK_CHANNEL: prime-alerts
     DATA_TRAFFIC_TOPIC: data-traffic
@@ -142,14 +142,13 @@ prime:
   resources: 
     requests:
       cpu: 300m
-      memory: 512Mi  
+      memory: 512Mi
   livenessProbe: {}
   readinessProbe: {}
   annotations: 
     prometheus.io/scrape: 'true'
     prometheus.io/path: '/prometheus-metrics'
     prometheus.io/port: '8081'  
-
 
 cloudsqlProxy:
   enabled: true
@@ -269,7 +268,7 @@ services:
       headers:
         x-mode: prime-direct
       # weight: 50   
-  
+
   dwadmin-service:
     name: dwadmin-service
     type: ClusterIP
@@ -294,7 +293,7 @@ services:
 certs:
   enabled: true
   dnsProvider: dev-clouddns
-  issuer: letsencrypt-production 
+  issuer: letsencrypt-production
   tlsSecretName: dev-oya-tls
   hosts:
     - '*.dev.oya.world'

--- a/prime/script/helm-deploy-dev-direct.sh
+++ b/prime/script/helm-deploy-dev-direct.sh
@@ -5,7 +5,7 @@
 ##
 
 
-DEPENDENCIES="./gradlew docker sed grep tr awk gcloud helm"
+DEPENDENCIES="./gradlew docker grep tr awk gcloud helm"
 for DEP in $DEPENDENCIES; do
     if [[ -z "$(which $DEP)" ]] ; then
 	echo "$0  ERROR: Missing dependency $DEP"
@@ -64,13 +64,13 @@ docker push eu.gcr.io/${GCP_PROJECT_ID}/prime:${TAG}
 
 HELM_RELEASE_NAME="prime-direct"
 HELM_CHART="ostelco/prime"
-HELM_CHART_VERSION="0.6.3"
+HELM_CHART_VERSION="1.0.0"
 HELM_VALUES_FILE="prime/infra/prime-direct-values.yaml"
 
 #
-# Then deploy using kubectl.
+# Then deploy using helm.
 #
-echo "Deploying prime to GKE"
+echo "Deploying prime-direct to GKE"
 
 helm repo add ostelco https://storage.googleapis.com/pi-ostelco-helm-charts-repo/
 helm repo update


### PR DESCRIPTION
This PR uses a new prime helm chart version (1.0.0) with updated deployment config. When merged, it will:

-  Enable deploying prime-direct with the same endpoints as dev and with header-based traffic filtering. (it is also possible to use weights).
- allow configuring canary settings for individual services.
- Split stable and canary deploys in prod so that they are independently deployable. 
- Introduce another manual step in the pipeline to promote canary to stable in prod.
- Schedule prime pods on specific nodes in dev and prod clusters.
- Reduce differences between prime-direct/dev/canary/stable prod deployment config and set the same resource requests for all.