### PR TITLE
Modify prime direct canary

### DIFF
--- a/.circleci/prime-dev-values.yaml
+++ b/.circleci/prime-dev-values.yaml
@@ -136,7 +136,7 @@ prime:
     - 8083 
   resources: 
     requests:
-      cpu: 300m
+      cpu: 100m
       memory: 512Mi
   livenessProbe: {}
   readinessProbe: {}

--- a/.circleci/prime-prod-values.yaml
+++ b/.circleci/prime-prod-values.yaml
@@ -139,7 +139,7 @@ prime:
 #      cpu: 200m
 #      memory: 400Mi
     requests:
-      cpu: 300m
+      cpu: 100m
       memory: 512Mi
   livenessProbe: {}
     # path: /

--- a/prime/build.gradle
+++ b/prime/build.gradle
@@ -20,7 +20,7 @@ sourceSets {
   }
 }
 
-version = "1.48.4"
+version = "1.48.5"
 
 repositories {
   maven {

--- a/prime/infra/README.md
+++ b/prime/infra/README.md
@@ -4,6 +4,25 @@
 
 For direct developer deployment for testing, use the [helm-deploy-dev-direct.sh](../script/helm-deploy-dev-direct.sh) shell script. 
 
+To change traffic routing/distribution between prime-direct (in default namespace) and prime (in dev namespace):
+
+> By default, prime direct accepts requests on the same endpoints (with the http header: x-mode=prime-direct) as prime dev which is deployed by CI.
+
+- To set all traffic to prime-direct (without headers)
+```
+./prime/script/change-prime-direct-canary.sh <service name, e.g. api> full-weight
+```
+
+- To set all traffic to prime (without headers)
+```
+./prime/script/change-prime-direct-canary.sh <service name, e.g. api> zero-weight
+```
+
+- To set traffic with the header `x-mode=prime-direct` to prime direct:
+```
+./prime/script/change-prime-direct-canary.sh <service name, e.g. api> header
+```
+
 ----- 
 
 ## Dev deployment

--- a/prime/infra/README.md
+++ b/prime/infra/README.md
@@ -9,17 +9,17 @@ To change traffic routing/distribution between prime-direct (in default namespac
 > By default, prime direct accepts requests on the same endpoints (with the http header: x-mode=prime-direct) as prime dev which is deployed by CI.
 
 - To set all traffic to prime-direct (without headers)
-```
+```bash
 ./prime/script/change-prime-direct-canary.sh <service name, e.g. api> full-weight
 ```
 
 - To set all traffic to prime (without headers)
-```
+```bash
 ./prime/script/change-prime-direct-canary.sh <service name, e.g. api> zero-weight
 ```
 
 - To set traffic with the header `x-mode=prime-direct` to prime direct:
-```
+```bash
 ./prime/script/change-prime-direct-canary.sh <service name, e.g. api> header
 ```
 

--- a/prime/infra/prime-direct-values.yaml
+++ b/prime/infra/prime-direct-values.yaml
@@ -31,7 +31,7 @@ cronjobs:
 
 prime:
   image: eu.gcr.io/pi-ostelco-dev/prime
-  tag: "1.48.1-dev-53b5fabc" # it will be set from CI
+  tag: "" # it will be set from CI
   pullPolicy: Always
   configDataBucket: "gs://pi-ostelco-dev-prime-files/dev"
 

--- a/prime/infra/prime-direct-values.yaml
+++ b/prime/infra/prime-direct-values.yaml
@@ -224,7 +224,6 @@ services:
     canary:
       headers:
         x-mode: prime-direct
-      # weight: 50   
 
   metrics:
     name: metrics
@@ -232,9 +231,6 @@ services:
     port: 443
     targetPort: 9443
     portName: grpc
-    # loadBalancerIP: x.y.z.n
-    # host: metrics # the host name is formulated from concatenating: dnsPrefix, this host, and dnsSuffix
-    # grpcOrHttp2: true
 
   prime-houston-api:
     name: houston-api
@@ -246,9 +242,7 @@ services:
     ambassadorMappingOptions:
       timeout_ms: 600000
     canary:
-      headers:
-        x-mode: prime-direct
-      # weight: 50   
+      weight: 0
 
   prime-alvin-api:
     name: alvin-api
@@ -260,9 +254,7 @@ services:
     ambassadorMappingOptions:
       timeout_ms: 600000
     canary:
-      headers:
-        x-mode: prime-direct
-      # weight: 50   
+      weight: 0
 
   dwadmin-service:
     name: dwadmin-service
@@ -281,9 +273,7 @@ services:
     clientCert: true
     caCert: smdp-cacert.dev # secretname.namespace
     canary:
-      headers:
-        x-mode: prime-direct
-      # weight: 50   
+      weight: 0
 
 certs:
   enabled: true

--- a/prime/infra/prime-direct-values.yaml
+++ b/prime/infra/prime-direct-values.yaml
@@ -31,7 +31,7 @@ cronjobs:
 
 prime:
   image: eu.gcr.io/pi-ostelco-dev/prime
-  tag: "" # it will be set from CI
+  tag: "1.48.1-dev-53b5fabc" # it will be set from CI
   pullPolicy: Always
   configDataBucket: "gs://pi-ostelco-dev-prime-files/dev"
 
@@ -136,7 +136,7 @@ prime:
     - 8083 
   resources: 
     requests:
-      cpu: 300m
+      cpu: 100m
       memory: 512Mi
   livenessProbe: {}
   readinessProbe: {}
@@ -164,7 +164,7 @@ ocsEsp:
     http2_port: 9000
     ssl_port: 8443
   secretVolumes:
-    - secretName: test-oya-tls
+    - secretName: dev-oya-tls
       containerMountPath: /etc/nginx/ssl
       type: ssl
 
@@ -183,7 +183,7 @@ metricsEsp:
     http2_port: 9004
     ssl_port: 9443
   secretVolumes:
-    - secretName: test-oya-tls
+    - secretName: dev-oya-tls
       containerMountPath: /etc/nginx/ssl
       type: ssl
 

--- a/prime/script/change-prime-direct-canary.sh
+++ b/prime/script/change-prime-direct-canary.sh
@@ -12,8 +12,8 @@ fi
 
 
 DEPENDENCIES="grep gcloud helm kubectl"
-for DEP in $DEPENDENCIES; do
-    if [[ -z "$(which $DEP)" ]] ; then
+for DEP in ${DEPENDENCIES}; do
+    if [[ -z "$(which ${DEP})" ]] ; then
 	echo "$0  ERROR: Missing dependency $DEP"
 	exit 1
     fi
@@ -34,7 +34,7 @@ SERVICE_NAME=$1
 CANARY_TYPE=$2
 HELM_SET_FLAG=" --set services.$SERVICE_NAME.canary"
 
-case $CANARY_TYPE in
+case ${CANARY_TYPE} in
 
   full-weight)
     echo "Setting prime direct traffic for [ $SERVICE_NAME ] service to %100."
@@ -78,4 +78,4 @@ echo "Upgrading prime-direct to GKE"
 
 helm repo add ostelco https://storage.googleapis.com/pi-ostelco-helm-charts-repo/
 helm repo update
-helm upgrade ${HELM_RELEASE_NAME} ${HELM_CHART} --version $HELM_CHART_VERSION --reuse-values $HELM_SET_FLAG
+helm upgrade ${HELM_RELEASE_NAME} ${HELM_CHART} --version ${HELM_CHART_VERSION} --reuse-values ${HELM_SET_FLAG}

--- a/prime/script/change-prime-direct-canary.sh
+++ b/prime/script/change-prime-direct-canary.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+##
+## Upgrade prime directly from workstation to configure canary traffic routing
+##
+
+#### sanity checks
+if [ -z $1 ] || [ -z $2 ]; then
+   echo "ERROR: missing (some) input parameters. Aborting!"
+   exit 1
+fi
+
+
+DEPENDENCIES="grep gcloud helm kubectl"
+for DEP in $DEPENDENCIES; do
+    if [[ -z "$(which $DEP)" ]] ; then
+	echo "$0  ERROR: Missing dependency $DEP"
+	exit 1
+    fi
+done
+
+# On error fail.
+set -e
+
+# Check that the script ss run from project root
+# (figure that out by looking for itself :-)
+if [[ ! -f prime/script/change-prime-direct-canary.sh ]] ; then
+    (>&2 echo "Run this script from project root dir (ostelco-core)")
+    exit 1
+fi
+####
+
+SERVICE_NAME=$1
+CANARY_TYPE=$2
+HELM_SET_FLAG=" --set services.$SERVICE_NAME.canary"
+
+case $CANARY_TYPE in
+
+  full-weight)
+    echo "Setting prime direct traffic for [ $SERVICE_NAME ] service to %100."
+    # HELM_SET_FLAG="${HELM_SET_FLAG}.weight=${WEIGHT_OR_HEADER} --set  services.$SERVICE_NAME.canary.headers={}"
+    HELM_SET_FLAG="${HELM_SET_FLAG}.weight=100,${HELM_SET_FLAG}.headers=null" 
+    ;;
+
+  zero-weight)
+    echo "Setting prime direct traffic for [ $SERVICE_NAME ] service to %0."
+    # HELM_SET_FLAG="${HELM_SET_FLAG}.weight=${WEIGHT_OR_HEADER} --set  services.$SERVICE_NAME.canary.headers={}"
+    HELM_SET_FLAG="${HELM_SET_FLAG}.weight=0,${HELM_SET_FLAG}.headers=null" 
+    ;;
+
+  header)
+    echo "Setting prime direct traffic for [ $SERVICE_NAME ] service to be based on header."
+    HELM_SET_FLAG="${HELM_SET_FLAG}.headers.x-mode=prime-direct"
+    ;;
+
+  *)
+    echo "ERROR: unknown canary type $CANARY_TYPE"
+    exit -1
+    ;;
+esac
+
+
+#
+# Use the  kubectl context containing the dev-cluster
+#
+K8S_CONTEXT="$(kubectl config get-contexts --output name | grep pi-ostelco-dev)"
+kubectl config use-context ${K8S_CONTEXT}
+
+
+HELM_RELEASE_NAME="prime-direct"
+HELM_CHART="ostelco/prime"
+HELM_CHART_VERSION="1.0.0"
+
+#
+# Then deploy using helm.
+#
+echo "Upgrading prime-direct to GKE"
+
+helm repo add ostelco https://storage.googleapis.com/pi-ostelco-helm-charts-repo/
+helm repo update
+helm upgrade ${HELM_RELEASE_NAME} ${HELM_CHART} --version $HELM_CHART_VERSION --reuse-values $HELM_SET_FLAG

--- a/prime/script/helm-deploy-dev-direct.sh
+++ b/prime/script/helm-deploy-dev-direct.sh
@@ -6,8 +6,8 @@
 
 
 DEPENDENCIES="./gradlew docker grep tr awk gcloud helm"
-for DEP in $DEPENDENCIES; do
-    if [[ -z "$(which $DEP)" ]] ; then
+for DEP in ${DEPENDENCIES}; do
+    if [[ -z "$(which ${DEP})" ]] ; then
 	echo "$0  ERROR: Missing dependency $DEP"
 	exit 1
     fi


### PR DESCRIPTION
this PR makes it possible to run commands for reconfiguring traffic routing between prime and prime-direct:

- To set all traffic to prime-direct (without headers)
```
./prime/script/change-prime-direct-canary.sh <service name, e.g. api> full-weight
```

- To set all traffic to prime (without headers)
```
./prime/script/change-prime-direct-canary.sh <service name, e.g. api> zero-weight
```

- To set traffic with the header `x-mode=prime-direct` to prime direct:
```
./prime/script/change-prime-direct-canary.sh <service name, e.g. api> header
```

