### PR TITLE
bumping helm chart version to 1.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,7 +269,7 @@ jobs:
             /authenticate.bash
             helm repo add ostelco https://storage.googleapis.com/pi-ostelco-helm-charts-repo/
             helm repo update
-            helm upgrade prime ostelco/prime --version 1.0.0 --install \
+            helm upgrade prime ostelco/prime --version 1.0.1 --install \
              --namespace dev \
              -f .circleci/prime-dev-values.yaml \
              --set prime.tag=$TAG 
@@ -330,7 +330,7 @@ jobs:
             /authenticate.bash
             helm repo add ostelco https://storage.googleapis.com/pi-ostelco-helm-charts-repo/
             helm repo update
-            helm upgrade prime ostelco/prime --version 1.0.0 --install \
+            helm upgrade prime ostelco/prime --version 1.0.1 --install \
              --namespace prod \
              -f .circleci/prime-canary-values.yaml \
              --set prime.tag=$TAG
@@ -365,7 +365,7 @@ jobs:
             /authenticate.bash
             helm repo add ostelco https://storage.googleapis.com/pi-ostelco-helm-charts-repo/
             helm repo update
-            helm upgrade prime ostelco/prime --version 1.0.0 --install \
+            helm upgrade prime ostelco/prime --version 1.0.1 --install \
              --namespace prod \
              -f .circleci/prime-prod-values.yaml \
              --set prime.tag=$TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,7 +330,7 @@ jobs:
             /authenticate.bash
             helm repo add ostelco https://storage.googleapis.com/pi-ostelco-helm-charts-repo/
             helm repo update
-            helm upgrade prime ostelco/prime --version 1.0.1 --install \
+            helm upgrade --install prime-canary ostelco/prime --version 1.0.1 \
              --namespace prod \
              -f .circleci/prime-canary-values.yaml \
              --set prime.tag=$TAG

--- a/prime/script/change-prime-direct-canary.sh
+++ b/prime/script/change-prime-direct-canary.sh
@@ -69,7 +69,7 @@ kubectl config use-context ${K8S_CONTEXT}
 
 HELM_RELEASE_NAME="prime-direct"
 HELM_CHART="ostelco/prime"
-HELM_CHART_VERSION="1.0.0"
+HELM_CHART_VERSION="1.0.1"
 
 #
 # Then deploy using helm.

--- a/prime/script/helm-deploy-dev-direct.sh
+++ b/prime/script/helm-deploy-dev-direct.sh
@@ -64,7 +64,7 @@ docker push eu.gcr.io/${GCP_PROJECT_ID}/prime:${TAG}
 
 HELM_RELEASE_NAME="prime-direct"
 HELM_CHART="ostelco/prime"
-HELM_CHART_VERSION="1.0.0"
+HELM_CHART_VERSION="1.0.1"
 HELM_VALUES_FILE="prime/infra/prime-direct-values.yaml"
 
 #


### PR DESCRIPTION
This fixes cronjobs not respecting node selectors and fixes canary deploy in the CI config.