### PR TITLE
Bumps Stripe library to 10.10.0 + adds workaround for JSON serialization issue the latest Stripe libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ subprojects {
     prometheusDropwizardVersion = "2.2.0"
     protocVersion="3.7.1" // updating to "3.9.0" causes compile errors in grpc generated code
     slf4jVersion="1.7.26"
-    stripeVersion = "10.3.0" // Updating to "10.9.0" breaks AT. 
+    stripeVersion = "10.10.0"
     swaggerVersion = "2.0.8"
     swaggerCodegenVersion = "2.4.7"
     testcontainersVersion = "1.11.4"

--- a/payment-processor/src/main/kotlin/org/ostelco/prime/paymentprocessor/StripePaymentProcessor.kt
+++ b/payment-processor/src/main/kotlin/org/ostelco/prime/paymentprocessor/StripePaymentProcessor.kt
@@ -67,7 +67,8 @@ class StripePaymentProcessor : PaymentProcessor {
     private fun getAccountDetails(paymentSource: PaymentSource): Map<String, Any> =
             when (paymentSource) {
                 is Card -> {
-                    mapOf("id" to paymentSource.id,
+                    mapOf(
+                            "id" to paymentSource.id,
                             "type" to "card",
                             "addressLine1" to paymentSource.addressLine1,
                             "addressLine2" to paymentSource.addressLine2,
@@ -83,15 +84,26 @@ class StripePaymentProcessor : PaymentProcessor {
                             "expMonth" to paymentSource.expMonth,
                             "expYear" to paymentSource.expYear,
                             "fingerprint" to paymentSource.fingerprint,
-                            "funding" to paymentSource.funding,
-                            "last4" to paymentSource.last4)              // Typ.: "credit" or "debit"
+                            "funding" to paymentSource.funding,         // "credit" or "debit"
+                            "last4" to paymentSource.last4)
                             .filterValues { it != null }
                 }
                 is Source -> {
-                    mapOf("id" to paymentSource.id,
+                    mapOf(
+                            "id" to paymentSource.id,
                             "type" to "source",
                             "created" to Instant.ofEpochSecond(paymentSource.created).toEpochMilli(),
-                            "owner" to paymentSource.owner,
+                            "owner" to mapOf(
+                                    "email" to paymentSource.owner.email,
+                                    "name" to paymentSource.owner.name,
+                                    "phone" to paymentSource.owner.phone,
+                                    "address" to mapOf(
+                                            "city" to paymentSource.owner.address.city,
+                                            "country" to paymentSource.owner.address.country,
+                                            "line1" to paymentSource.owner.address.line1,
+                                            "line2" to paymentSource.owner.address.line2,
+                                            "postalCode" to paymentSource.owner.address.postalCode,
+                                            "state" to paymentSource.owner.address.state)),
                             "threeDSecure" to paymentSource.threeDSecure)
                 }
                 else -> {


### PR DESCRIPTION
With previous Stripe libraries Jersey could serialize objects returned
from Stripe to JSON. With library version >= 10.9.0 at least, this
fails. The workaround is to convert such objects to maps before handing
them to Jersey.