### PR TITLE
Commenting out (falsely) failing healtcheck, since it gives errors in…

### DIFF
--- a/sim-administration/simmanager/src/integration-test/kotlin/org/ostelco/simcards/admin/SimAdministrationTest.kt
+++ b/sim-administration/simmanager/src/integration-test/kotlin/org/ostelco/simcards/admin/SimAdministrationTest.kt
@@ -441,7 +441,7 @@ class SimAdministrationTest {
 
         assertHealthy("db")
         assertHealthy("postgresql")
-        assertHealthy("smdp")
+        //  assertHealthy("smdp") TODO: Commented out since it fails in pre-prod, and is disabled in the app.
     }
 
 

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/admin/SimAdministrationModule.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/admin/SimAdministrationModule.kt
@@ -114,8 +114,10 @@ class SimAdministrationModule : PrimeModule {
                 hssAdapterProxy = hssAdapters,
                 profileVendors = config.profileVendors))
 
-        env.healthChecks().register("smdp",
-                SmdpPlusHealthceck(getDAO(), httpClient, config.profileVendors))
+        // TODO: Commented out as a hotfix since it continously failing, probably falsely
+        //       shuld be fixed asap to ensure that warnings are real.
+        // env.healthChecks().register("smdp",
+        //        SmdpPlusHealthceck(getDAO(), httpClient, config.profileVendors))
 
         // logging request and response contents
         env.servlets()


### PR DESCRIPTION
… pre-prod environment when talking to a real sm-dp+