### PR TITLE
Sim manager refactoring

### DIFF
--- a/prime-modules/src/main/kotlin/org/ostelco/prime/simmanager/SimManagerError.kt
+++ b/prime-modules/src/main/kotlin/org/ostelco/prime/simmanager/SimManagerError.kt
@@ -2,11 +2,11 @@ package org.ostelco.prime.simmanager
 
 import org.ostelco.prime.apierror.InternalError
 
-sealed class SimManagerError(var description: String, val error: InternalError?) : InternalError()
+sealed class SimManagerError(var description: String, val error: InternalError?,  val pingOk: Boolean = false) : InternalError()
 
-class NotFoundError(description: String, error: InternalError? = null) : SimManagerError(description, error = error)
+class NotFoundError(description: String, error: InternalError? = null, pingOk: Boolean = false) : SimManagerError(description, error = error, pingOk = pingOk)
 
-class NotUpdatedError(description: String, error: InternalError? = null) : SimManagerError(description, error = error)
+class NotUpdatedError(description: String, error: InternalError? = null, pingOk: Boolean = false) : SimManagerError(description, error = error, pingOk=pingOk)
 
 class ForbiddenError(description: String, error: InternalError? = null) : SimManagerError(description, error = error)
 

--- a/sim-administration/es2plus4dropwizard/src/main/kotlin/org/ostelco/sim/es2plus/Es2PlusEntities.kt
+++ b/sim-administration/es2plus4dropwizard/src/main/kotlin/org/ostelco/sim/es2plus/Es2PlusEntities.kt
@@ -152,7 +152,7 @@ data class Es2ConfirmOrder(
         @JsonProperty("matchingId") val matchingId: String? = null,
         @JsonProperty("confirmationCode") val confirmationCode: String? = null,
         @JsonProperty("smdpAddress") val smdpAddress: String? = null,
-        @JsonProperty("releaseFlag") val releaseFlag: Boolean
+        @JsonProperty("releaseFlag") val releaseFlag: Boolean = true
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/sim-administration/es2plus4dropwizard/src/main/kotlin/org/ostelco/sim/es2plus/Es2PlusEntities.kt
+++ b/sim-administration/es2plus4dropwizard/src/main/kotlin/org/ostelco/sim/es2plus/Es2PlusEntities.kt
@@ -77,7 +77,7 @@ data class Es2PlusDownloadOrder(
 data class Es2DownloadOrderResponse(
         @JsonProperty("header") val header: ES2ResponseHeader = eS2SuccessResponseHeader(),
         @JsonProperty("iccid") val iccid: String? = null
-): EsResponse(header)
+): Es2Response(header)
 
 
 ///
@@ -126,7 +126,7 @@ data class Es2ProfileStatusResponse(
         @JsonProperty("header") val header: ES2ResponseHeader = eS2SuccessResponseHeader(),
         @JsonProperty("profileStatusList") val profileStatusList: List<ProfileStatus>? = listOf(),
         @JsonProperty("completionTimestamp") val completionTimestamp: String? = getNowAsDatetime()
-)
+): Es2Response(myHeader = header)
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class ProfileStatus(
@@ -156,7 +156,7 @@ data class Es2ConfirmOrder(
         @JsonProperty("releaseFlag") val releaseFlag: Boolean = true
 )
 
-sealed class EsResponse(val myHeader: ES2ResponseHeader)
+sealed class Es2Response(val myHeader: ES2ResponseHeader)
 
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -166,7 +166,7 @@ data class Es2ConfirmOrderResponse(
         @JsonProperty("eid") val eid: String? = null,
         @JsonProperty("matchingId") val matchingId: String? = null,
         @JsonProperty("smdpAddress") val smdsAddress: String? = null
-): EsResponse(myHeader =  header)
+): Es2Response(myHeader =  header)
 
 ///
 ///  The CancelOrder function

--- a/sim-administration/es2plus4dropwizard/src/main/kotlin/org/ostelco/sim/es2plus/Es2PlusEntities.kt
+++ b/sim-administration/es2plus4dropwizard/src/main/kotlin/org/ostelco/sim/es2plus/Es2PlusEntities.kt
@@ -71,7 +71,6 @@ data class Es2PlusDownloadOrder(
         @JsonProperty("profileType") val profileType: String? = null
 )
 
-sealed class EsResponse(val myHeader: ES2ResponseHeader)
 
 @JsonSchema("ES2+DownloadOrder-response")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -157,6 +156,9 @@ data class Es2ConfirmOrder(
         @JsonProperty("releaseFlag") val releaseFlag: Boolean = true
 )
 
+sealed class EsResponse(val myHeader: ES2ResponseHeader)
+
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonSchema("ES2+ConfirmOrder-response")
 data class Es2ConfirmOrderResponse(
@@ -164,7 +166,7 @@ data class Es2ConfirmOrderResponse(
         @JsonProperty("eid") val eid: String? = null,
         @JsonProperty("matchingId") val matchingId: String? = null,
         @JsonProperty("smdpAddress") val smdsAddress: String? = null
-)
+): EsResponse(myHeader =  header)
 
 ///
 ///  The CancelOrder function

--- a/sim-administration/es2plus4dropwizard/src/main/kotlin/org/ostelco/sim/es2plus/Es2PlusEntities.kt
+++ b/sim-administration/es2plus4dropwizard/src/main/kotlin/org/ostelco/sim/es2plus/Es2PlusEntities.kt
@@ -71,12 +71,14 @@ data class Es2PlusDownloadOrder(
         @JsonProperty("profileType") val profileType: String? = null
 )
 
+sealed class EsResponse(val myHeader: ES2ResponseHeader)
+
 @JsonSchema("ES2+DownloadOrder-response")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class Es2DownloadOrderResponse(
         @JsonProperty("header") val header: ES2ResponseHeader = eS2SuccessResponseHeader(),
         @JsonProperty("iccid") val iccid: String? = null
-)
+): EsResponse(header)
 
 
 ///

--- a/sim-administration/es2plus4dropwizard/src/main/kotlin/org/ostelco/sim/es2plus/Es2PlusEntities.kt
+++ b/sim-administration/es2plus4dropwizard/src/main/kotlin/org/ostelco/sim/es2plus/Es2PlusEntities.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import org.ostelco.jsonschema.JsonSchema
 import org.ostelco.sim.es2plus.ES2PlusClient.Companion.getNowAsDatetime
-import java.util.UUID
 
 
 ///
@@ -23,7 +22,7 @@ import java.util.UUID
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class ES2RequestHeader(
         @JsonProperty("functionRequesterIdentifier") val functionRequesterIdentifier: String,
-        @JsonProperty("functionCallIdentifier") val functionCallIdentifier: String = UUID.randomUUID().toString()
+        @JsonProperty("functionCallIdentifier") val functionCallIdentifier: String = ES2PlusClient.newRandomFunctionCallIdentifier()
 )
 
 ///

--- a/sim-administration/simmanager/src/integration-test/kotlin/org/ostelco/simcards/admin/SimAdministrationTest.kt
+++ b/sim-administration/simmanager/src/integration-test/kotlin/org/ostelco/simcards/admin/SimAdministrationTest.kt
@@ -172,7 +172,7 @@ class SimAdministrationTest {
     private fun presetTables() {
         val dao = SIM_MANAGER_RULE.getApplication<SimAdministrationApplication>().getDAO()
 
-        dao.addProfileVendorAdapter(profileVendor)
+        dao.addProfileVendorDatumAdapter(profileVendor)
         dao.addHssEntry(hssName)
         dao.permitVendorForHssByNames(profileVendor = profileVendor, hssName = hssName)
     }

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/admin/SmdpPlusHealthceck.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/admin/SmdpPlusHealthceck.kt
@@ -9,6 +9,7 @@ import org.apache.http.impl.client.CloseableHttpClient
 import org.ostelco.prime.getLogger
 import org.ostelco.prime.simmanager.SimManagerError
 import org.ostelco.simcards.inventory.SimInventoryDAO
+import org.ostelco.simcards.profilevendors.ProfileVendorAdapter
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -69,20 +70,22 @@ class SmdpPlusHealthceck(
 
                     val profileVendorAdaptorList = vendorsRaw.bind()
 
-                    loopOverAllProfileVendors@ for (profileVendor in profileVendorAdaptorList) {
-                        logger.info("Processing vendor: $profileVendor")
+                    loopOverAllProfileVendors@ for (vendorAdapterDatum in profileVendorAdaptorList) {
+                        logger.info("Processing vendor: $vendorAdapterDatum")
                         val currentConfig: ProfileVendorConfig? =
-                                profileVendorConfigList.firstOrNull { it.name == profileVendor.name }
+                                profileVendorConfigList.firstOrNull { it.name == vendorAdapterDatum.name }
 
                         if (currentConfig == null) {
-                            val msg = "Could not find config for profile vendor '${profileVendor.name}' while attempting to ping remote SM-DP+ adapter"
+                            val msg = "Could not find config for profile vendor '${vendorAdapterDatum.name}' while attempting to ping remote SM-DP+ adapter"
                             logger.error(msg)
                             throw RuntimeException(msg) // TODO: I really dont like this style of coding.
                         }
 
+                        val vendorAdapter = ProfileVendorAdapter(vendorAdapterDatum)
+
                         // This isn't working very well in the acceptance tests, so we need to log a little.
                         logger.info("About to ping config: $currentConfig")
-                        val pingResult = profileVendor.ping(
+                        val pingResult = vendorAdapter.ping(
                                 httpClient = httpClient,
                                 config = currentConfig
                         )

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/admin/SmdpPlusHealthceck.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/admin/SmdpPlusHealthceck.kt
@@ -96,7 +96,7 @@ class SmdpPlusHealthceck(
                                 continue@loopOverAllProfileVendors
                             } else {
                                 logger.error("Could not reach SM-DP+ via HTTP PING:", pingResult)
-                                throw RuntimeException(msg) // TODO: I really dont like this style of coding.
+                                throw RuntimeException("Could not reach SM-DP+ via HTTP PING: $pingResult") // TODO: I really dont like this style of coding.
                             }
                             is Either.Right -> {
                             }

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryApi.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryApi.kt
@@ -15,7 +15,7 @@ import org.ostelco.prime.simmanager.SimManagerError
 import org.ostelco.sim.es2plus.ProfileStatus
 import org.ostelco.simcards.admin.ProfileVendorConfig
 import org.ostelco.simcards.admin.SimAdministrationConfiguration
-import org.ostelco.simcards.profilevendors.ProfileVendorAdapter
+import org.ostelco.simcards.profilevendors.ProfileVendorAdapterDatum
 import java.io.InputStream
 
 
@@ -134,7 +134,7 @@ class SimInventoryApi(private val httpClient: CloseableHttpClient,
     //       let the new item that is generated (replacing the pair) be called ProfileVendorAdapter,
     //       and then remove most of the parameters for the methods of that class.  That will simplify logic
     //       and permit removal of a sizable chunk of code, so it seems like  good refactoring to attempt.
-    private fun getProfileVendorAdapterAndConfig(simEntry: SimEntry): Either<SimManagerError, Pair<ProfileVendorAdapter, ProfileVendorConfig>> =
+    private fun getProfileVendorAdapterAndConfig(simEntry: SimEntry): Either<SimManagerError, Pair<ProfileVendorAdapterDatum, ProfileVendorConfig>> =
             dao.getProfileVendorAdapterById(simEntry.profileVendorId)
                     .flatMap { profileVendorAdapter ->
                         val config: ProfileVendorConfig? = config.profileVendors.firstOrNull {

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryApi.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryApi.kt
@@ -128,6 +128,12 @@ class SimInventoryApi(private val httpClient: CloseableHttpClient,
                             simEntry.right()
                     }
 
+    // TODO: Design flaw! This thing shouldn't return a pair, it should return an object that can actually
+    //       do something useful.  That will be the target of refactoring r.s.n.
+    //       The _best_ thing to do, would be to rename the entry in the database as ProfileVendor,
+    //       let the new item that is generated (replacing the pair) be called ProfileVendorAdapter,
+    //       and then remove most of the parameters for the methods of that class.  That will simplify logic
+    //       and permit removal of a sizable chunk of code, so it seems like  good refactoring to attempt.
     private fun getProfileVendorAdapterAndConfig(simEntry: SimEntry): Either<SimManagerError, Pair<ProfileVendorAdapter, ProfileVendorConfig>> =
             dao.getProfileVendorAdapterById(simEntry.profileVendorId)
                     .flatMap { profileVendorAdapter ->

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryApi.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryApi.kt
@@ -15,6 +15,7 @@ import org.ostelco.prime.simmanager.SimManagerError
 import org.ostelco.sim.es2plus.ProfileStatus
 import org.ostelco.simcards.admin.ProfileVendorConfig
 import org.ostelco.simcards.admin.SimAdministrationConfiguration
+import org.ostelco.simcards.profilevendors.ProfileVendorAdapter
 import org.ostelco.simcards.profilevendors.ProfileVendorAdapterDatum
 import java.io.InputStream
 
@@ -60,7 +61,9 @@ class SimInventoryApi(private val httpClient: CloseableHttpClient,
                     .flatMap { simEntry ->
                         getProfileVendorAdapterAndConfig(simEntry)
                                 .flatMap {
-                                    it.first.getProfileStatus(httpClient, it.second, iccid)
+                                    val profileVendorAdapterDatum = it.first
+                                    val provileVendorCondfig = it.second
+                                    ProfileVendorAdapter(profileVendorAdapterDatum).getProfileStatus(httpClient, provileVendorCondfig, iccid)
                                 }
                     }
 
@@ -100,7 +103,7 @@ class SimInventoryApi(private val httpClient: CloseableHttpClient,
                     initialHssState: HssState): Either<SimManagerError, SimImportBatch> =
             IO {
                 Either.monad<SimManagerError>().binding {
-                    val profileVendorAdapter = dao.getProfileVendorAdapterByName(simVendor)
+                    val profileVendorAdapter = dao.getProfileVendorAdapterDatumByName(simVendor)
                             .bind()
                     val hlrAdapter = dao.getHssEntryByName(hlrName)
                             .bind()
@@ -135,7 +138,7 @@ class SimInventoryApi(private val httpClient: CloseableHttpClient,
     //       and then remove most of the parameters for the methods of that class.  That will simplify logic
     //       and permit removal of a sizable chunk of code, so it seems like  good refactoring to attempt.
     private fun getProfileVendorAdapterAndConfig(simEntry: SimEntry): Either<SimManagerError, Pair<ProfileVendorAdapterDatum, ProfileVendorConfig>> =
-            dao.getProfileVendorAdapterById(simEntry.profileVendorId)
+            dao.getProfileVendorAdapterDatumById(simEntry.profileVendorId)
                     .flatMap { profileVendorAdapter ->
                         val config: ProfileVendorConfig? = config.profileVendors.firstOrNull {
                             it.name == profileVendorAdapter.name

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryDAO.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryDAO.kt
@@ -204,7 +204,7 @@ class SimInventoryDAO(private val db: SimInventoryDBWrapperImpl) : SimInventoryD
     fun permitVendorForHssByNames(profileVendor: String, hssName: String): Either<SimManagerError, Boolean> =
             IO {
                 Either.monad<SimManagerError>().binding {
-                    val profileVendorAdapter = getProfileVendorAdapterByName(profileVendor)
+                    val profileVendorAdapter = getProfileVendorAdapterDatumByName(profileVendor)
                             .bind()
                     val hlrAdapter = getHssEntryByName(hssName)
                             .bind()

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryDB.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryDB.kt
@@ -10,7 +10,7 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery
 import org.jdbi.v3.sqlobject.statement.SqlUpdate
 import org.jdbi.v3.sqlobject.transaction.Transaction
 import org.ostelco.simcards.hss.HssEntry
-import org.ostelco.simcards.profilevendors.ProfileVendorAdapter
+import org.ostelco.simcards.profilevendors.ProfileVendorAdapterDatum
 import java.sql.ResultSet
 
 /**
@@ -171,15 +171,15 @@ interface SimInventoryDB {
     fun addProfileVendorAdapter(name: String): Int
 
     @SqlQuery("""SELECT * FROM profile_vendor_adapters""")
-    fun getAllProfileVendors(): List<ProfileVendorAdapter>
+    fun getAllProfileVendors(): List<ProfileVendorAdapterDatum>
 
     @SqlQuery("""SELECT * FROM profile_vendor_adapters
                        WHERE name = :name""")
-    fun getProfileVendorAdapterByName(name: String): ProfileVendorAdapter?
+    fun getProfileVendorAdapterByName(name: String): ProfileVendorAdapterDatum?
 
     @SqlQuery("""SELECT * FROM profile_vendor_adapters
                       WHERE id = :id""")
-    fun getProfileVendorAdapterById(id: Long): ProfileVendorAdapter?
+    fun getProfileVendorAdapterById(id: Long): ProfileVendorAdapterDatum?
 
     /**
      * Batch handling.

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryDBWrapper.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryDBWrapper.kt
@@ -3,7 +3,7 @@ package org.ostelco.simcards.inventory
 import arrow.core.Either
 import org.ostelco.prime.simmanager.SimManagerError
 import org.ostelco.simcards.hss.HssEntry
-import org.ostelco.simcards.profilevendors.ProfileVendorAdapter
+import org.ostelco.simcards.profilevendors.ProfileVendorAdapterDatum
 
 
 interface SimInventoryDBWrapper {
@@ -20,7 +20,7 @@ interface SimInventoryDBWrapper {
 
     fun findNextReadyToUseSimProfileForHss(hssId: Long, profile: String): Either<SimManagerError, SimEntry>
 
-    fun getAllProfileVendors(): Either<SimManagerError, List<ProfileVendorAdapter>>
+    fun getAllProfileVendors(): Either<SimManagerError, List<ProfileVendorAdapterDatum>>
 
     /**
      * Sets the EID value of a SIM entry (profile).
@@ -102,9 +102,9 @@ interface SimInventoryDBWrapper {
 
     fun addProfileVendorAdapter(name: String): Either<SimManagerError, Int>
 
-    fun getProfileVendorAdapterByName(name: String): Either<SimManagerError, ProfileVendorAdapter>
+    fun getProfileVendorAdapterByName(name: String): Either<SimManagerError, ProfileVendorAdapterDatum>
 
-    fun getProfileVendorAdapterById(id: Long): Either<SimManagerError, ProfileVendorAdapter>
+    fun getProfileVendorAdapterById(id: Long): Either<SimManagerError, ProfileVendorAdapterDatum>
 
     /*
      * Batch handling.

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryDBWrapper.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryDBWrapper.kt
@@ -100,11 +100,11 @@ interface SimInventoryDBWrapper {
 
     fun getHssEntryById(id: Long): Either<SimManagerError, HssEntry>
 
-    fun addProfileVendorAdapter(name: String): Either<SimManagerError, Int>
+    fun addProfileVendorDatumAdapter(name: String): Either<SimManagerError, Int>
 
-    fun getProfileVendorAdapterByName(name: String): Either<SimManagerError, ProfileVendorAdapterDatum>
+    fun getProfileVendorAdapterDatumByName(name: String): Either<SimManagerError, ProfileVendorAdapterDatum>
 
-    fun getProfileVendorAdapterById(id: Long): Either<SimManagerError, ProfileVendorAdapterDatum>
+    fun getProfileVendorAdapterDatumById(id: Long): Either<SimManagerError, ProfileVendorAdapterDatum>
 
     /*
      * Batch handling.

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryDBWrapperImpl.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryDBWrapperImpl.kt
@@ -156,7 +156,7 @@ class SimInventoryDBWrapperImpl(private val db: SimInventoryDB) : SimInventoryDB
                 db.getHssEntryById(id)
             }
 
-    override fun addProfileVendorAdapter(name: String): Either<SimManagerError, Int> =
+    override fun addProfileVendorDatumAdapter(name: String): Either<SimManagerError, Int> =
             either {
                 db.addProfileVendorAdapter(name)
             }
@@ -169,12 +169,12 @@ class SimInventoryDBWrapperImpl(private val db: SimInventoryDB) : SimInventoryDB
                 db.getAllProfileVendors()
             }
 
-    override fun getProfileVendorAdapterByName(name: String): Either<SimManagerError, ProfileVendorAdapterDatum> =
+    override fun getProfileVendorAdapterDatumByName(name: String): Either<SimManagerError, ProfileVendorAdapterDatum> =
             either(NotFoundError("Found no SIM profile vendor with metricName $name")) {
                 db.getProfileVendorAdapterByName(name)
             }
 
-    override fun getProfileVendorAdapterById(id: Long): Either<SimManagerError, ProfileVendorAdapterDatum> =
+    override fun getProfileVendorAdapterDatumById(id: Long): Either<SimManagerError, ProfileVendorAdapterDatum> =
             either(NotFoundError("Found no SIM profile vendor with id $id")) {
                 db.getProfileVendorAdapterById(id)
             }

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryDBWrapperImpl.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryDBWrapperImpl.kt
@@ -161,8 +161,10 @@ class SimInventoryDBWrapperImpl(private val db: SimInventoryDB) : SimInventoryDB
                 db.addProfileVendorAdapter(name)
             }
 
-
     override fun getAllProfileVendors(): Either<SimManagerError, List<ProfileVendorAdapter>> =
+            // TODO: Bug! An empty list is a perfectly valid result, not a error, is it OK
+            //       to return that result as an error (similar arguments apply to the
+            //       methods below).
             either(NotFoundError("Found no SIM profile vendors.")) {
                 db.getAllProfileVendors()
             }

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryDBWrapperImpl.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/inventory/SimInventoryDBWrapperImpl.kt
@@ -11,7 +11,7 @@ import org.ostelco.prime.simmanager.NotFoundError
 import org.ostelco.prime.simmanager.SimManagerError
 import org.ostelco.prime.simmanager.SystemError
 import org.ostelco.simcards.hss.HssEntry
-import org.ostelco.simcards.profilevendors.ProfileVendorAdapter
+import org.ostelco.simcards.profilevendors.ProfileVendorAdapterDatum
 import org.postgresql.util.PSQLException
 
 
@@ -161,7 +161,7 @@ class SimInventoryDBWrapperImpl(private val db: SimInventoryDB) : SimInventoryDB
                 db.addProfileVendorAdapter(name)
             }
 
-    override fun getAllProfileVendors(): Either<SimManagerError, List<ProfileVendorAdapter>> =
+    override fun getAllProfileVendors(): Either<SimManagerError, List<ProfileVendorAdapterDatum>> =
             // TODO: Bug! An empty list is a perfectly valid result, not a error, is it OK
             //       to return that result as an error (similar arguments apply to the
             //       methods below).
@@ -169,12 +169,12 @@ class SimInventoryDBWrapperImpl(private val db: SimInventoryDB) : SimInventoryDB
                 db.getAllProfileVendors()
             }
 
-    override fun getProfileVendorAdapterByName(name: String): Either<SimManagerError, ProfileVendorAdapter> =
+    override fun getProfileVendorAdapterByName(name: String): Either<SimManagerError, ProfileVendorAdapterDatum> =
             either(NotFoundError("Found no SIM profile vendor with metricName $name")) {
                 db.getProfileVendorAdapterByName(name)
             }
 
-    override fun getProfileVendorAdapterById(id: Long): Either<SimManagerError, ProfileVendorAdapter> =
+    override fun getProfileVendorAdapterById(id: Long): Either<SimManagerError, ProfileVendorAdapterDatum> =
             either(NotFoundError("Found no SIM profile vendor with id $id")) {
                 db.getProfileVendorAdapterById(id)
             }

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/profilevendors/ProfileVendorAdapter.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/profilevendors/ProfileVendorAdapter.kt
@@ -53,11 +53,6 @@ data class ProfileVendorAdapter(
 
 
     //  This class is currently the target of an ongoing refactoring.
-    //   * First refactor getProfileStatus, confirmOrder and downloadOrder extensively,
-    //     to ensure that any true differences stand out clearly, and repeated code
-    //     is kept elsewhere.   Make the code _very_clear.
-    //   * Incredibly important, but only apparent after several rounds of initial refactoring:
-    //         => Make the control flow obviously clear!
     //   * See if the code can be made much clearer still by injecting HTTP client
     //     etc. as class parameters.
     //   * Then  replace both with invocations to the possibly updated

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/profilevendors/ProfileVendorAdapter.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/profilevendors/ProfileVendorAdapter.kt
@@ -188,7 +188,7 @@ data class ProfileVendorAdapter(
         val header = ES2RequestHeader(functionRequesterIdentifier = config.requesterIdentifier)
         val iccid = simEntry.iccid
         val request =
-                buildEs2plusRequest<Es2ConfirmOrder>(config.es2plusEndpoint, "confirmOrder",
+                buildEs2plusRequest<Es2ConfirmOrder>(config.getEndpoint(), "confirmOrder",
                         Es2ConfirmOrder(
                                 header = header,
                                 eid = eid,
@@ -341,7 +341,7 @@ data class ProfileVendorAdapter(
                 functionRequesterIdentifier = config.requesterIdentifier)
 
         val request =
-                buildEs2plusRequest<Es2PlusProfileStatus>(config.es2plusEndpoint, "confirmOrder",
+                buildEs2plusRequest<Es2PlusProfileStatus>(config.getEndpoint(), "confirmOrder",
                         Es2PlusProfileStatus(
                                 header = header,
                                 iccidList = iccidList.map { IccidListEntry(iccid = it) }
@@ -366,7 +366,8 @@ data class ProfileVendorAdapter(
                                     iccids,
                                     status.header.functionExecutionStatus,
                                     functionCallIdentifier)
-                            NotUpdatedError("SM-DP+ 'profile-status' to ${config.name} failed with status: ${status.header.functionExecutionStatus}")
+                            NotUpdatedError("SM-DP+ 'profile-status' to ${config.name} failed with status: ${status.header.functionExecutionStatus}",
+                                    pingOk=true)
                                     .left()
 
                         } else {
@@ -379,7 +380,8 @@ data class ProfileVendorAdapter(
                             if (!profileStatusList.isNullOrEmpty())
                                 profileStatusList.right()
                             else
-                                NotFoundError("No information found for ICCID $iccids in SM-DP+ 'profile-status' message to service ${config.name}")
+                                NotFoundError("No information found for ICCID $iccids in SM-DP+ 'profile-status' message to service ${config.name}",
+                                        pingOk=true)
                                         .left()
                         }
                     }

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/profilevendors/ProfileVendorAdapter.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/profilevendors/ProfileVendorAdapter.kt
@@ -21,7 +21,7 @@ import org.ostelco.sim.es2plus.Es2ConfirmOrder
 import org.ostelco.sim.es2plus.Es2ConfirmOrderResponse
 import org.ostelco.sim.es2plus.Es2DownloadOrderResponse
 import org.ostelco.sim.es2plus.Es2PlusDownloadOrder
-import org.ostelco.sim.es2plus.Es2PlusProfileStatus
+import org.ostelco.sim.es2plus.Es2ProfileStatusCommand
 import org.ostelco.sim.es2plus.Es2ProfileStatusResponse
 import org.ostelco.sim.es2plus.FunctionExecutionStatus
 import org.ostelco.sim.es2plus.FunctionExecutionStatusType
@@ -341,8 +341,8 @@ data class ProfileVendorAdapter(
                 functionRequesterIdentifier = config.requesterIdentifier)
 
         val request =
-                buildEs2plusRequest<Es2PlusProfileStatus>(config.getEndpoint(), "confirmOrder",
-                        Es2PlusProfileStatus(
+                buildEs2plusRequest<Es2ProfileStatusCommand>(config.getEndpoint(), "getProfileStatus",
+                        Es2ProfileStatusCommand(
                                 header = header,
                                 iccidList = iccidList.map { IccidListEntry(iccid = it) }
                         ))

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/profilevendors/ProfileVendorAdapter.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/profilevendors/ProfileVendorAdapter.kt
@@ -152,6 +152,8 @@ data class ProfileVendorAdapter(
     //   * First refactor confirmOrder and downloadOrder extensively,
     //     to ensure that any true differences stand out clearly, and repeated code
     //     is kept elsewhere.
+    //   * Incredibly important, but only apparent after several rounds of initial refactoring:
+    //         => Make the control flow clear!
     //   * Then  replace both with invocations to the possibly updated
     //     ES2+ client library.
 

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/profilevendors/ProfileVendorAdapter.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/profilevendors/ProfileVendorAdapter.kt
@@ -28,7 +28,6 @@ import org.ostelco.simcards.admin.ProfileVendorConfig
 import org.ostelco.simcards.inventory.SimEntry
 import org.ostelco.simcards.inventory.SimInventoryDAO
 import org.ostelco.simcards.inventory.SmDpPlusState
-import java.util.*
 import javax.ws.rs.core.MediaType
 
 /**
@@ -163,9 +162,7 @@ data class ProfileVendorAdapter(
                              simEntry: SimEntry): Either<SimManagerError, SimEntry> {
 
         val header = ES2RequestHeader(
-                functionRequesterIdentifier = config.requesterIdentifier,
-                functionCallIdentifier = UUID.randomUUID().toString()
-        )
+                functionRequesterIdentifier = config.requesterIdentifier)
         val body = Es2ConfirmOrder(
                 header = header,
                 eid = eid,
@@ -296,9 +293,7 @@ data class ProfileVendorAdapter(
         }
 
         val header = ES2RequestHeader(
-                functionRequesterIdentifier = config.requesterIdentifier,
-                functionCallIdentifier = UUID.randomUUID().toString()
-        )
+                functionRequesterIdentifier = config.requesterIdentifier)
         val body = Es2PlusProfileStatus(
                 header = header,
                 iccidList = iccidList.map { IccidListEntry(iccid = it) }

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/profilevendors/ProfileVendorAdapter.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/profilevendors/ProfileVendorAdapter.kt
@@ -91,6 +91,8 @@ data class ProfileVendorAdapter(
         private fun executionWasFailure(status: FunctionExecutionStatus) =
                 status.status != FunctionExecutionStatusType.ExecutedSuccess
 
+
+        // TODO: Future refactoring: Move this code into the ES2PlusClient, more or less.
         fun <T : Es2Response> executeRequest(
                 es2CommandName: String,
                 httpClient: CloseableHttpClient,
@@ -209,13 +211,16 @@ data class ProfileVendorAdapter(
                         return AdapterError("simEntryId == null or empty").left()
                     }
 
-                    // TODO: Check if we even care about eid at this point.
-                    //  if (simEntry.eid != null && simEntry.eid != response.eid) {
-                    //      return AdapterError("simEntry.eid = '${simEntry.eid}', response.eid = '${response.eid}'").left()
-                    // }
+                    // TODO: Perhaps check consistency of eid values at this point.
+                    //       Not  important with current usecases, but possibly
+                    //       in the future.
 
                     dao.setSmDpPlusStateAndMatchingId(simEntry.id, SmDpPlusState.RELEASED, response.matchingId!!)
-                    dao.getSimProfileById(simEntry.id) // TODO DO we really want to do this?
+
+                    // TODO Do we really want to do this?  Do we need the
+                    //      sim entry value as a returnv value?   If we don't then
+                    //      remove the next line.
+                    dao.getSimProfileById(simEntry.id)
                 }
     }
 
@@ -279,12 +284,13 @@ data class ProfileVendorAdapter(
 
                     val profileStatusList = response.profileStatusList
 
-                    if (!profileStatusList.isNullOrEmpty())
+                    if (!profileStatusList.isNullOrEmpty()) {
                         profileStatusList.right()
-                    else
+                    } else {
                         NotFoundError("No information found for ICCID $iccids in SM-DP+ 'profile-status' message to service ${config.name}",
                                 pingOk = true)
                                 .left()
+                    }
                 }
     }
 

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/profilevendors/ProfileVendorAdapterDatum.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/profilevendors/ProfileVendorAdapterDatum.kt
@@ -44,7 +44,7 @@ import javax.ws.rs.core.MediaType
  * TODO:  Why on earth is the json property set to "metricName"? It makes no sense.
  *        Fix it, but understand what it means.
  */
-data class ProfileVendorAdapter(
+data class ProfileVendorAdapterDatum(
         @JsonProperty("id") val id: Long,
         @JsonProperty("metricName") val name: String) {
 

--- a/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/profilevendors/ProfileVendorAdapterDatum.kt
+++ b/sim-administration/simmanager/src/main/kotlin/org/ostelco/simcards/profilevendors/ProfileVendorAdapterDatum.kt
@@ -46,8 +46,10 @@ import javax.ws.rs.core.MediaType
  */
 data class ProfileVendorAdapterDatum(
         @JsonProperty("id") val id: Long,
-        @JsonProperty("metricName") val name: String) {
+        @JsonProperty("metricName") val name: String)
 
+
+data class ProfileVendorAdapter(val datum: ProfileVendorAdapterDatum) {
 
     private val logger by getLogger()
 

--- a/sim-administration/simmanager/src/test/kotlin/org/ostelco/simcards/inventory/SimInventoryUnitTests.kt
+++ b/sim-administration/simmanager/src/test/kotlin/org/ostelco/simcards/inventory/SimInventoryUnitTests.kt
@@ -20,7 +20,7 @@ import org.ostelco.simcards.admin.ProfileVendorConfig
 import org.ostelco.simcards.admin.SimAdministrationConfiguration
 import org.ostelco.simcards.admin.SwtHssConfig
 import org.ostelco.simcards.hss.HssEntry
-import org.ostelco.simcards.profilevendors.ProfileVendorAdapter
+import org.ostelco.simcards.profilevendors.ProfileVendorAdapterDatum
 import java.io.InputStream
 import java.util.*
 import javax.ws.rs.client.Entity
@@ -36,7 +36,7 @@ class SimInventoryUnitTests {
 
         private val dao = mock(SimInventoryDAO::class.java)
         private val hssEntry = mock(HssEntry::class.java)
-        private val profileVendorAdapter = mock(ProfileVendorAdapter::class.java)
+        private val profileVendorAdapter = mock(ProfileVendorAdapterDatum::class.java)
         private val httpClient = mock(CloseableHttpClient::class.java)
 
         @JvmField

--- a/sim-administration/simmanager/src/test/kotlin/org/ostelco/simcards/inventory/SimInventoryUnitTests.kt
+++ b/sim-administration/simmanager/src/test/kotlin/org/ostelco/simcards/inventory/SimInventoryUnitTests.kt
@@ -36,7 +36,7 @@ class SimInventoryUnitTests {
 
         private val dao = mock(SimInventoryDAO::class.java)
         private val hssEntry = mock(HssEntry::class.java)
-        private val profileVendorAdapter = mock(ProfileVendorAdapterDatum::class.java)
+        private val profileVendorAdapterDatum = mock(ProfileVendorAdapterDatum::class.java)
         private val httpClient = mock(CloseableHttpClient::class.java)
 
         @JvmField
@@ -95,7 +95,7 @@ class SimInventoryUnitTests {
     fun setUp() {
         reset(dao)
         reset(hssEntry)
-        reset(profileVendorAdapter)
+        reset(profileVendorAdapterDatum)
 
         /* HssConfig */
         org.mockito.Mockito.`when`(hssConfig.name)
@@ -127,14 +127,11 @@ class SimInventoryUnitTests {
 
 
         /* Profile vendor profilevendors. */
-        org.mockito.Mockito.`when`(profileVendorAdapter.id)
+        org.mockito.Mockito.`when`(profileVendorAdapterDatum.id)
                 .thenReturn(1L)
-        org.mockito.Mockito.`when`(profileVendorAdapter.name)
+        org.mockito.Mockito.`when`(profileVendorAdapterDatum.name)
                 .thenReturn(fakeProfileVendor)
-        org.mockito.Mockito.`when`(profileVendorAdapter.activate(httpClient, profileVendorConfig, dao, null, fakeSimEntryWithoutMsisdn))
-                .thenReturn(fakeSimEntryWithoutMsisdn.copy(
-                        smdpPlusState = SmDpPlusState.RELEASED).right())
-
+   
         /* DAO. */
         org.mockito.Mockito.`when`(dao.getSimProfileByIccid(fakeIccid1))
                 .thenReturn(fakeSimEntryWithoutMsisdn.right())
@@ -169,11 +166,11 @@ class SimInventoryUnitTests {
         org.mockito.Mockito.`when`(dao.getHssEntryByName(fakeHlr))
                 .thenReturn(Either.Right(hssEntry))
 
-        org.mockito.Mockito.`when`(dao.getProfileVendorAdapterByName(fakeProfileVendor))
-                .thenReturn(profileVendorAdapter.right())
+        org.mockito.Mockito.`when`(dao.getProfileVendorAdapterDatumByName(fakeProfileVendor))
+                .thenReturn(profileVendorAdapterDatum.right())
 
-        org.mockito.Mockito.`when`(dao.getProfileVendorAdapterById(1L))
-                .thenReturn(profileVendorAdapter.right())
+        org.mockito.Mockito.`when`(dao.getProfileVendorAdapterDatumById(1L))
+                .thenReturn(profileVendorAdapterDatum.right())
 
         org.mockito.Mockito.`when`(dao.getHssEntryByName(fakeHlr))
                 .thenReturn(Either.Right(hssEntry))
@@ -209,7 +206,7 @@ class SimInventoryUnitTests {
 
         val simEntry = response.readEntity(SimEntry::class.java)
         verify(dao).getSimProfileByIccid(fakeIccid1)
-        verify(dao).getProfileVendorAdapterById(fakeSimEntryWithoutMsisdn.profileVendorId)
+        verify(dao).getProfileVendorAdapterDatumById(fakeSimEntryWithoutMsisdn.profileVendorId)
         assertNotNull(simEntry)
         assertEquals(fakeSimEntryWithoutMsisdn, simEntry)
     }

--- a/sim-administration/simmanager/src/test/kotlin/org/ostelco/simcards/inventory/SimInventoryUnitTests.kt
+++ b/sim-administration/simmanager/src/test/kotlin/org/ostelco/simcards/inventory/SimInventoryUnitTests.kt
@@ -131,7 +131,7 @@ class SimInventoryUnitTests {
                 .thenReturn(1L)
         org.mockito.Mockito.`when`(profileVendorAdapterDatum.name)
                 .thenReturn(fakeProfileVendor)
-   
+
         /* DAO. */
         org.mockito.Mockito.`when`(dao.getSimProfileByIccid(fakeIccid1))
                 .thenReturn(fakeSimEntryWithoutMsisdn.right())

--- a/sim-administration/uploader/upload-sim-batch.go
+++ b/sim-administration/uploader/upload-sim-batch.go
@@ -68,7 +68,6 @@ func calculateChecksum(luhnString string, double bool) int {
 
 		checksum += n
 	}
-
 	return checksum
 }
 
@@ -105,7 +104,7 @@ func isICCID(s string) bool {
 
 func checkICCIDSyntax(name string, potentialIccid string) {
 	if !isICCID(potentialIccid) {
-		log.Fatal("Not a valid %s ICCID: '%s'.  Must be 18 or 19 digits.", name, potentialIccid)
+		log.Fatalf("Not a valid %s ICCID: '%s'.  Must be 18 or 19 digits (excluding luhn checksum).", name, potentialIccid)
 	}
 }
 
@@ -116,7 +115,7 @@ func isIMSI(s string) bool {
 
 func checkIMSISyntax(name string, potentialIMSI string) {
 	if !isIMSI(potentialIMSI) {
-		log.Fatal("Not a valid %s IMSI: '%s'.  Must be 15 digits.", name, potentialIMSI)
+		log.Fatalf("Not a valid %s IMSI: '%s'.  Must be 15 digits.", name, potentialIMSI)
 	}
 }
 
@@ -127,7 +126,7 @@ func isMSISDN(s string) bool {
 
 func checkMSISDNSyntax(name string, potentialMSISDN string) {
 	if !isMSISDN(potentialMSISDN) {
-		log.Fatal("Not a valid %s MSISDN: '%s'.  Must be non-empty sequence of digits.", name, potentialMSISDN)
+		log.Fatalf("Not a valid %s MSISDN: '%s'.  Must be non-empty sequence of digits.", name, potentialMSISDN)
 	}
 }
 
@@ -238,7 +237,7 @@ func parseCommandLine() Batch {
 
 	var firstImsiInt, _ = Atoi(*firstIMSI)
 	var lastImsiInt, _ = Atoi(*lastIMSI)
-	var imsiLen = lastImsiInt - firstImsiInt
+	var imsiLen = lastImsiInt - firstImsiInt + 1
 
 	var firstIccidInt, _ = Atoi(iccidWithoutLuhnChecksum(*firstIccid))
 	var lastIccidInt, _ = Atoi(iccidWithoutLuhnChecksum(*lastIccid))

--- a/sim-administration/uploader/upload-sim-batch.go
+++ b/sim-administration/uploader/upload-sim-batch.go
@@ -234,9 +234,15 @@ func parseCommandLine() Batch {
 
 	// Convert to integers, and get lengths
 
+	log.Println("firstmsisdn =", *firstMsisdn)
+	log.Println("lastmsisdn =", *lastMsisdn)
+
 	var firstMsisdnInt, _ = Atoi(*firstMsisdn)
 	var lastMsisdnInt, _ = Atoi(*lastMsisdn)
-	var msisdnLen = lastMsisdnInt - firstMsisdnInt
+	var msisdnLen =  lastMsisdnInt - firstMsisdnInt + 1
+	if msisdnLen < 0 {
+		msisdnLen = - msisdnLen
+	}
 
 	var firstImsiInt, _ = Atoi(*firstIMSI)
 	var lastImsiInt, _ = Atoi(*lastIMSI)


### PR DESCRIPTION
1. Fix the ES2+ ping protocol used to check if the SM-DP+ in the other end is answering requests.
2. One round of refactoring of ProfileVendorAdapter.kt.  This round of refactoring consists of 
    a) Introducing a set of methods that factor out a lot of repeated code.
    b) Removing some functionality (in particular with respect to eid), that is not necessary for our current usecases, and maybe also not correct.  All in all, this simplification makes the code much more compact and easy to read.