### PR TITLE
Changed to Dispathers.IO for neo4j calls

### DIFF
--- a/neo4j-store/src/main/kotlin/org/ostelco/prime/storage/graph/Schema.kt
+++ b/neo4j-store/src/main/kotlin/org/ostelco/prime/storage/graph/Schema.kt
@@ -555,7 +555,7 @@ object Graph {
 
     suspend fun <R> writeSuspended(query: String, transaction: Transaction, transform: (CompletionStage<StatementResultCursor>) -> R) {
         LOG.trace("write:[\n$query\n]")
-        withContext(Dispatchers.Default) {
+        withContext(Dispatchers.IO) {
             trace.childSpan("neo4j.writeAsync") {
                 transaction.runAsync(query)
             }


### PR DESCRIPTION
For DB and network calls it is recommended to use Dispatchers.IO instead of Dispatchers.Default which is optimized to perform CPU-intensive work.

