### PR TITLE
Fix for warnings about reflective access at start

### DIFF
--- a/scaninfo-shredder/script/start.sh
+++ b/scaninfo-shredder/script/start.sh
@@ -3,5 +3,7 @@
 # Start app
 exec java \
      -Dfile.encoding=UTF-8 \
+     --add-opens java.base/java.lang=ALL-UNNAMED \
+     --add-opens java.base/java.io=ALL-UNNAMED \
      -Xshare:on \
      -jar /scaninfo-shredder.jar shred config/config.yaml


### PR DESCRIPTION
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.fasterxml.jackson.module.afterburner.util.MyClassLoader (file:/scaninfo-shredder.jar) to method java.lang.ClassLoader.findLoadedClass(java.lang.String)
WARNING: Please consider reporting this to the maintainers of com.fasterxml.jackson.module.afterburner.util.MyClassLoader
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release