### PR TITLE
Bumps Stipe Java library version from 12.0.0 to 13.1.0

### DIFF
--- a/buildSrc/src/main/kotlin/org/ostelco/prime/gradle/Version.kt
+++ b/buildSrc/src/main/kotlin/org/ostelco/prime/gradle/Version.kt
@@ -47,7 +47,7 @@ object Version {
   const val slf4j = "1.7.28"
   // IMPORTANT: When Stripe SDK library version is updated, check if the Stripe API version has changed.
   // If so, then update API version in Stripe Web Console for callback Webhooks.
-  const val stripe = "12.0.0"
+  const val stripe = "13.1.0"
   const val swagger = "2.0.9"
   const val swaggerCodegen = "2.4.8"
   const val testcontainers = "1.12.1"


### PR DESCRIPTION
Remember to update default API version in Stripe console from
2019-09-09 to 2019-10-08.