### PR TITLE
Remove duplicate entries in the notification  token list.

### DIFF
--- a/document-data-store/src/main/kotlin/org/ostelco/prime/storage/documentstore/DocumentDataStore.kt
+++ b/document-data-store/src/main/kotlin/org/ostelco/prime/storage/documentstore/DocumentDataStore.kt
@@ -36,6 +36,12 @@ object DocumentDataStoreSingleton : DocumentStore {
             .getOrElse { emptyList() }
 
     override fun addNotificationToken(customerId: String, token: ApplicationToken): Boolean {
+        // Remove any other entries with the same token.
+        getNotificationTokens(customerId).forEach {
+            if (it.tokenType == token.tokenType && it.token == token.token && it.applicationID != token.applicationID) {
+                removeNotificationToken(customerId, it.applicationID)
+            }
+        }
         return notificationTokenStore.put(
                 token,
                 token.applicationID,


### PR DESCRIPTION
The application id coming from the app is generated using the
identifierForVendor iOS API. This can change for the same device
depending on varios factors (see the documentation)

So we will use the token from FCM to cleanup any duplicate entries.