### PR TITLE
Fix exception reporting in DelegatePubSubPublisher

### DIFF
--- a/analytics-module/src/main/kotlin/org/ostelco/prime/analytics/publishers/DelegatePubSubPublisher.kt
+++ b/analytics-module/src/main/kotlin/org/ostelco/prime/analytics/publishers/DelegatePubSubPublisher.kt
@@ -57,17 +57,18 @@ class DelegatePubSubPublisher(
         ApiFutures.addCallback(future, object : ApiFutureCallback<String> {
 
             override fun onFailure(throwable: Throwable) {
+                logger.warn("Error publishing message in topic: $topicId")
                 if (throwable is ApiException) {
                     // details on the API exception
-                    logger.warn("Status code: {}", throwable.statusCode.code)
-                    logger.warn("Retrying: {}", throwable.isRetryable)
+                    logger.warn("Pubsub topic: $topicId\n" +
+                            "Status code: ${throwable.statusCode.code}\n" +
+                            "Retrying: ${throwable.isRetryable}")
                 }
-                logger.warn("Error publishing message in topic: $topicId")
             }
 
             override fun onSuccess(messageId: String) {
                 // Once published, returns server-assigned message ids (unique within the topic)
-                logger.debug("Published message $messageId")
+                logger.debug("Published message $messageId to topic $topicId")
             }
         }, DataConsumptionInfoPublisher.singleThreadScheduledExecutor)
     }

--- a/analytics-module/src/main/kotlin/org/ostelco/prime/analytics/publishers/DelegatePubSubPublisher.kt
+++ b/analytics-module/src/main/kotlin/org/ostelco/prime/analytics/publishers/DelegatePubSubPublisher.kt
@@ -61,6 +61,7 @@ class DelegatePubSubPublisher(
                 if (throwable is ApiException) {
                     // details on the API exception
                     logger.warn("Pubsub topic: $topicId\n" +
+                            "Message : ${throwable.message}\n" +
                             "Status code: ${throwable.statusCode.code}\n" +
                             "Retrying: ${throwable.isRetryable}")
                 }

--- a/analytics-module/src/main/kotlin/org/ostelco/prime/analytics/publishers/DelegatePubSubPublisher.kt
+++ b/analytics-module/src/main/kotlin/org/ostelco/prime/analytics/publishers/DelegatePubSubPublisher.kt
@@ -57,13 +57,14 @@ class DelegatePubSubPublisher(
         ApiFutures.addCallback(future, object : ApiFutureCallback<String> {
 
             override fun onFailure(throwable: Throwable) {
-                logger.warn("Error publishing message in topic: $topicId")
                 if (throwable is ApiException) {
                     // details on the API exception
-                    logger.warn("Pubsub topic: $topicId\n" +
-                            "Message : ${throwable.message}\n" +
+                    logger.warn("Error publishing message to Pubsub topic: $topicId\n" +
+                            "Message: ${throwable.message}\n" +
                             "Status code: ${throwable.statusCode.code}\n" +
                             "Retrying: ${throwable.isRetryable}")
+                } else {
+                    logger.warn("Error publishing message to Pubsub topic: $topicId")
                 }
             }
 

--- a/ocs-ktc/src/main/kotlin/org/ostelco/prime/ocs/consumption/pubsub/PubSubClient.kt
+++ b/ocs-ktc/src/main/kotlin/org/ostelco/prime/ocs/consumption/pubsub/PubSubClient.kt
@@ -101,8 +101,10 @@ class PubSubClient(
             override fun onFailure(throwable: Throwable) {
                 if (throwable is ApiException) {
                     // details on the API exception
-                    logger.error("Status code: {}", throwable.statusCode.code)
-                    logger.error("Retrying: {}", throwable.isRetryable)
+                    logger.warn("Pubsub messageId: $messageId\n" +
+                            "Message : ${throwable.message}\n" +
+                            "Status code: ${throwable.statusCode.code}\n" +
+                            "Retrying: ${throwable.isRetryable}")
                 }
                 logger.error("Error sending CCR Request to PubSub")
             }

--- a/ocs-ktc/src/main/kotlin/org/ostelco/prime/ocs/consumption/pubsub/PubSubClient.kt
+++ b/ocs-ktc/src/main/kotlin/org/ostelco/prime/ocs/consumption/pubsub/PubSubClient.kt
@@ -105,8 +105,9 @@ class PubSubClient(
                             "Message : ${throwable.message}\n" +
                             "Status code: ${throwable.statusCode.code}\n" +
                             "Retrying: ${throwable.isRetryable}")
+                } else {
+                    logger.error("Error sending CCR Request to PubSub. messageId: $messageId")
                 }
-                logger.error("Error sending CCR Request to PubSub")
             }
 
             override fun onSuccess(messageId: String) {

--- a/ocsgw/src/main/java/org/ostelco/ocsgw/datasource/protobuf/PubSubDataSource.kt
+++ b/ocsgw/src/main/java/org/ostelco/ocsgw/datasource/protobuf/PubSubDataSource.kt
@@ -119,8 +119,10 @@ class PubSubDataSource(
             override fun onFailure(throwable: Throwable) {
                 if (throwable is ApiException) {
                     // details on the API exception
-                    logger.warn("Status code: {}", throwable.statusCode.code)
-                    logger.warn("Retrying: {}", throwable.isRetryable)
+                    logger.warn("Pubsub topic: $ccaTopicId\n" +
+                            "Message : ${throwable.message}\n" +
+                            "Status code: ${throwable.statusCode.code}\n" +
+                            "Retrying: ${throwable.isRetryable}")
                 }
                 logger.warn("Error sending CCR Request to PubSub")
             }

--- a/ocsgw/src/main/java/org/ostelco/ocsgw/datasource/protobuf/PubSubDataSource.kt
+++ b/ocsgw/src/main/java/org/ostelco/ocsgw/datasource/protobuf/PubSubDataSource.kt
@@ -120,11 +120,13 @@ class PubSubDataSource(
                 if (throwable is ApiException) {
                     // details on the API exception
                     logger.warn("Pubsub topic: $ccaTopicId\n" +
+                            "RequestId : ${creditControlRequestInfo.requestId} \n" +
                             "Message : ${throwable.message}\n" +
                             "Status code: ${throwable.statusCode.code}\n" +
                             "Retrying: ${throwable.isRetryable}")
+                } else {
+                    logger.warn("Error sending CCR Request to PubSub. topic: $ccaTopicId requestId ${creditControlRequestInfo.requestId}")
                 }
-                logger.warn("Error sending CCR Request to PubSub")
             }
 
             override fun onSuccess(messageId: String) {


### PR DESCRIPTION
One call to logger.warn instead of two

Refers to https://www.notion.so/redotter/Improve-error-logging-for-failed-Pub-Sub-message-submit-cf71316870e44b3780b50adae3016082