### PR TITLE
Fix TCC Timer issue when session is moved between gateways

### DIFF
--- a/diameter-ha/src/main/kotlin/org/ostelco/diameter/ha/timer/ReplicatedTimerTaskData.kt
+++ b/diameter-ha/src/main/kotlin/org/ostelco/diameter/ha/timer/ReplicatedTimerTaskData.kt
@@ -81,6 +81,7 @@ class ReplicatedTimerTask(val data: ReplicatedTimerTaskData, private val session
             runTask()
         } else {
             // clear local session. As the timer was created by this instance it should be local.
+            logger.debug("Skipping Timer with id ${data.taskID}, removing session ${data.sessionId}")
             sessionDataSource.removeSession(data.sessionId)
         }
     }

--- a/ocsgw/src/main/java/org/ostelco/ocsgw/OcsApplication.java
+++ b/ocsgw/src/main/java/org/ostelco/ocsgw/OcsApplication.java
@@ -140,7 +140,7 @@ public class OcsApplication extends CCASessionFactoryImpl implements NetworkReqL
                 try {
                     OcsServer.INSTANCE.handleRequest$ocsgw(session, request);
                 } catch (Exception e) {
-                    LOG.error("[><] Failure processing Credit-Control-Request [" + RequestType.getTypeAsString(request.getRequestTypeAVPValue()) + "]", e);
+                    LOG.error("[><] Failure processing Credit-Control-Request [" + RequestType.getTypeAsString(request.getRequestTypeAVPValue()) + "] + [session.getSessionId()]", e);
                 }
                 break;
             case RequestType.EVENT_REQUEST:


### PR DESCRIPTION
Since the session can be moved from one OCS gateway instance to
another, we might end up with trailing timers on the instence
from which the session was moved. The TCC Timer will setback the
state of the session to IDLE which might not be true as it now
lives on another node. This will disable the timer. Since the
gateway does not store any reservation locally it is not needed
at this point.