### PR TITLE
Disable notification when user cancels KYC 

### DIFF
--- a/neo4j-store/src/main/kotlin/org/ostelco/prime/storage/graph/Neo4jStore.kt
+++ b/neo4j-store/src/main/kotlin/org/ostelco/prime/storage/graph/Neo4jStore.kt
@@ -1746,12 +1746,15 @@ object Neo4jStoreSingleton : GraphStore {
                                         transaction = transaction)
                             }
                 } else {
-                    // TODO: find out what more information can be passed to the client.
-                    appNotifier.notify(
-                            notificationType = NotificationType.JUMIO_VERIFICATION_FAILED,
-                            customerId = customer.id,
-                            data = extendedStatus
-                    )
+                    // Do not notify the app when the verification fails because the customer has cancelled and hence did not upload an ID.
+                    if (updatedScanInformation.scanResult?.verificationStatus != "NO_ID_UPLOADED") {
+                        // TODO: find out what more information can be passed to the client.
+                        appNotifier.notify(
+                                notificationType = NotificationType.JUMIO_VERIFICATION_FAILED,
+                                customerId = customer.id,
+                                data = extendedStatus
+                        )
+                    }
                     logger.info(NOTIFY_OPS_MARKER, "Jumio verification failed for ${customer.contactEmail} Info: $extendedStatus")
                     setKycStatus(
                             customer = customer,

--- a/prime/build.gradle.kts
+++ b/prime/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 // Update version in [script/start.sh] too.
-version = "1.71.0"
+version = "1.71.1"
 
 dependencies {
   // interface module between prime and prime-modules

--- a/prime/script/start.sh
+++ b/prime/script/start.sh
@@ -5,5 +5,5 @@ exec java \
     -Dfile.encoding=UTF-8 \
     --add-opens java.base/java.lang=ALL-UNNAMED \
     --add-opens java.base/java.io=ALL-UNNAMED \
-    -agentpath:/opt/cprof/profiler_java_agent.so=-cprof_service=prime,-cprof_service_version=1.71.0,-logtostderr,-minloglevel=2,-cprof_enable_heap_sampling \
+    -agentpath:/opt/cprof/profiler_java_agent.so=-cprof_service=prime,-cprof_service_version=1.71.1,-logtostderr,-minloglevel=2,-cprof_enable_heap_sampling \
     -jar /prime.jar server /config/config.yaml


### PR DESCRIPTION
Do not notify the app when the verification fails because the customer has cancelled and hence did not upload an ID.