### PR TITLE
Fix missing stripe event message

### DIFF
--- a/payment-processor/script/update-webhook.sh
+++ b/payment-processor/script/update-webhook.sh
@@ -24,6 +24,7 @@ update_event_list() {
          -d enabled_events[]="customer.deleted" \
          -d enabled_events[]="customer.subscription.created" \
          -d enabled_events[]="customer.subscription.deleted" \
+         -d enabled_events[]="customer.subscription.updated" \
          -d enabled_events[]="invoice.created" \
          -d enabled_events[]="invoice.deleted" \
          -d enabled_events[]="invoice.finalized" \

--- a/payment-processor/src/main/kotlin/org/ostelco/prime/paymentprocessor/subscribers/Reporter.kt
+++ b/payment-processor/src/main/kotlin/org/ostelco/prime/paymentprocessor/subscribers/Reporter.kt
@@ -272,6 +272,14 @@ object Reporter {
                         format("${email(subscription.customer)} subscribed to ${subscription.plan.id}",
                                 event)
                 )
+                event.type == "customer.subscription.updated" -> logger.info(
+                        format("${email(subscription.customer)} subscription to ${subscription.plan.id} got updated",
+                                event)
+                )
+                event.type == "customer.subscription.deleted" -> logger.info(NOTIFY_OPS_MARKER,
+                        format("${email(subscription.customer)} subscription to ${subscription.plan.id} got deleted",
+                                event)
+                )
                 else -> logger.warn(format("Unhandled Stripe event ${event.type} (cat: Subscription)",
                         event))
             }
@@ -280,6 +288,8 @@ object Reporter {
 
     private fun url(eventId: String): String = "https://dashboard.stripe.com/events/${eventId}"
 
+    /* TODO (kmm) Update to use the java.text.NumberFormat API or the new
+            JSR-354 Currency and Money API. */
     private fun currency(amount: Long, currency: String): String =
             when (currency.toUpperCase()) {
                 "SGD", "USD" -> "\$"

--- a/prime/infra/stripe-monitor-task.yaml
+++ b/prime/infra/stripe-monitor-task.yaml
@@ -28,6 +28,7 @@ spec:
                            "customer.deleted",
                            "customer.subscription.created",
                            "customer.subscription.deleted",
+                           "customer.subscription.updated",
                            "invoice.created",
                            "invoice.deleted",
                            "invoice.finalized",


### PR DESCRIPTION
https://www.notion.so/redotter/Unhandled-Stripe-event-customer-subscription-deleted-cat-Subscription-48d483fbfae24df482b71647194d7b0b